### PR TITLE
Remove accidental blocking of Fabric icons

### DIFF
--- a/src/util/fabric/theme.ts
+++ b/src/util/fabric/theme.ts
@@ -36,7 +36,6 @@ const fontStyles = {
         lineHeight: '2.0rem',
       },
       mediumPlus: fontStyles,
-      icon: fontStyles,
       large: {
         ...fontStyles,
         fontSize: '1.8rem',


### PR DESCRIPTION
This was removing Fabric's icon URLs from the theme config. Noticed when rendering a Dropdown component