### PR TITLE
Change pkill pattern, and pin yarn v0.27.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM travisci/ci-nodejs:packer-1494866191
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && sudo apt-get install yarn
+RUN apt-get update && sudo apt-get install yarn=0.27.5-1
 RUN su - travis -c "nvm install 6.11.3"
 
 ENV APP_ROOT /usr/src/yamui

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "storybook:start": "start-storybook --port 5555 --config-dir config/storybook",
     "storybook:static:build": "yarn clean:docs && build-storybook --config-dir config/storybook --output-dir docs",
     "storybook:static:serve": "serve docs --port 5555",
-    "storybook:static:stop": "pkill -f \"sh -c serve docs --port 5555\"",
+    "storybook:static:stop": "pkill -f \"node_modules/.bin/serve docs\"",
     "visual:test": "backstop test --config config/backstop/config.js",
     "visual:approve": "backstop approve --config config/backstop/config.js",
     "prepublishOnly": "yarn build"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "report": "run-p report:*",
     "storybook:start": "start-storybook --port 5555 --config-dir config/storybook",
     "storybook:static:build": "yarn clean:docs && build-storybook --config-dir config/storybook --output-dir docs",
-    "storybook:static:serve": "serve docs --port 5555",
+    "storybook:static:serve": "serve docs --port 5555 || true",
     "storybook:static:stop": "pkill -f \"node_modules/.bin/serve docs\"",
     "visual:test": "backstop test --config config/backstop/config.js",
     "visual:approve": "backstop approve --config config/backstop/config.js",


### PR DESCRIPTION
The `sh -c serve docs` task is the parent of the `node_modules/.bin/serve docs` task. It's probably better to kill the child and let the parent terminate because of that. Also pkill may not find the process if it was started with a shell other than `sh`?

Also, we've seen that yarn v1.0.0 treats tasks that receive a SIGTERM as if they errored, which screws the way we run our visual tests. We're going to pin the version to v0.27.5 until we find a better solution.