### PR TITLE
Setup Travis to auto-release to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,20 @@ node_js:
   - "6.11.3"
 
 branches:
-   only:
-     - master
+  only:
+    - master
 
 script:
   - yarn run test
 
 after_success:
   - ./config/travis/build.sh
+
+deploy:
+  provider: npm
+  email: unindented@gmail.com
+  api_key:
+    secure: d1MleHtP/AMY2AZCtheaK2ZtDsrWTZDs2CSGQR2RicypMKfzBaxnZ9sha7EaN4hC8vXJgdEf0yYVrFc2JwH763WQ90BmDQokPvQgCVeJ6eiQkGrmnNle5lXq7gDToh4WZKnNzXRSXnFe/bi4TGGNmsLYlA+jbJBSjvD7buTPSSS/ycsPfKoP/fLw0H8v+v9HuEjZPnc1lJ6qaK86n5NAmtuAzvcQDBOorYu9+VdjM0uSW6Q6lrZaexyCtiLYVqYCB/Btr+vX1wARqjhxFtZD4gIVOvvbS73RniFlwiNWVhEN2b4O44CpdNdBKhf2FZGtzvNN2VF7i0MBt6yoCTrm5U5t9wVPv7BwTcy4LUqK7OCNdtkMt82iPmi/TdAff4CXtSjKZMrK+ZNaZ2iL36x/qxQvAk1mSqfAgjkkapQ4dZW5kPGBNOIjXgaOXPDFuboYVrEhRWHF0jXcHWqzwRKflrNQ8MTgnTVPKKZdm50qQqUblFxReIBGLH1eJV+0QnkyUBoYfwpojgH7OMB4EDOBnbAuil7lZCJAltEEOz3Y7cSsowmVDuBJ3I22i+NMMs5Ta/wyOc0lub6sEaiQmIdhZaq6bhvzsrhXOjH8VtEGw1w1zbHYpdycdIhMIr7JHx7rO9Pm93px2P9euEwb1v/H+qWMJwqz+OzAWOdl+YoQ6cg=
+  on:
+    tags: true
+    repo: Microsoft/YamUI


### PR DESCRIPTION
Travis is able to publish tagged releases automatically to npm. So releasing a new version of YamUI would only involve doing:

```
$ git checkout -b release-new-version
$ npm version patch "Release version %s"
$ git push
```

Once the pull request is reviewed and merged, Travis will publish to npm.