### PR TITLE
Add font-display optional to font-faces

### DIFF
--- a/src/css/font-face.css
+++ b/src/css/font-face.css
@@ -17,6 +17,7 @@
         url('https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-regular.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
+  font-display: optional;
 }
 
 
@@ -34,6 +35,7 @@
         url('https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-light.ttf') format('truetype');
   font-weight: 100;
   font-style: normal;
+  font-display: optional;
 }
 @font-face {
   font-family: 'Segoe UI WestEuropean';
@@ -43,6 +45,7 @@
         url('https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-semilight.ttf') format('truetype');
   font-weight: 200;
   font-style: normal;
+  font-display: optional;
 }
 @font-face {
   font-family: 'Segoe UI WestEuropean';
@@ -52,4 +55,5 @@
         url('https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-semibold.ttf') format('truetype');
   font-weight: 600;
   font-style: normal;
+  font-display: optional;
 }


### PR DESCRIPTION
# *Add font-display: optional to font-faces*

`font-display: optional` allows the browser to unblock initial page render, use the fallback until it can load the font, either on subsequent load, or by swapping it out if it loads quickly enough... More info and demo videos here: https://www.sitepoint.com/css-font-display-future-font-rendering-web/

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [ ] Component visual reference files are up-to-date.
* [x] Component is unit tested.

No component/functional changes...