### PR TITLE
Exploring broken visual diffs in Styleguidist branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -586,6 +586,29 @@
         }
       }
     },
+    "acorn-object-spread": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-object-spread/-/acorn-object-spread-1.0.0.tgz",
+      "integrity": "sha1-SOrQ9KjrFplaF6Dbn/xqyq2kumg=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "address": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.0.2.tgz",
+      "integrity": "sha1-SACB6CtYe6MZRZ/vUS9Rb+A9WK8=",
+      "dev": true
+    },
     "airbnb-js-shims": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-1.3.0.tgz",
@@ -643,6 +666,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "anser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.1.tgz",
+      "integrity": "sha1-w2QYY6lizr75Qeoshwbyy08HFr0=",
       "dev": true
     },
     "ansi-align": {
@@ -718,6 +747,12 @@
       "requires": {
         "default-require-extensions": "1.0.0"
       }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.9",
@@ -818,6 +853,12 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.9.0"
       }
+    },
+    "array-iterate": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.1.tgz",
+      "integrity": "sha1-hlv3+K851rCYLGCQKRSsdrwBCPY=",
+      "dev": true
     },
     "array-map": {
       "version": "0.0.0",
@@ -2223,6 +2264,12 @@
         }
       }
     },
+    "bail": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
+      "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q=",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2239,6 +2286,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
       "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
+      "dev": true
+    },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -2291,6 +2344,28 @@
         "qs": "6.5.1",
         "raw-body": "2.3.2",
         "type-is": "1.6.15"
+      }
+    },
+    "bonjour": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+      "dev": true,
+      "requires": {
+        "array-flatten": "2.1.1",
+        "deep-equal": "1.0.1",
+        "dns-equal": "1.0.0",
+        "dns-txt": "2.0.2",
+        "multicast-dns": "6.1.1",
+        "multicast-dns-service-types": "1.1.0"
+      },
+      "dependencies": {
+        "array-flatten": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+          "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+          "dev": true
+        }
       }
     },
     "boolbase": {
@@ -2482,6 +2557,44 @@
         "node-int64": "0.4.0"
       }
     },
+    "buble": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/buble/-/buble-0.15.2.tgz",
+      "integrity": "sha1-VH/EdIP45egXbYKqXrzLGDsC1hM=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0",
+        "acorn-jsx": "3.0.1",
+        "acorn-object-spread": "1.0.0",
+        "chalk": "1.1.3",
+        "magic-string": "0.14.0",
+        "minimist": "1.2.0",
+        "os-homedir": "1.0.2"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.14.0.tgz",
+          "integrity": "sha1-VyJK7xcByu7Sc7F6OalW5ysXJGI=",
+          "dev": true,
+          "requires": {
+            "vlq": "0.2.3"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -2492,6 +2605,12 @@
         "ieee754": "1.1.8",
         "isarray": "1.0.0"
       }
+    },
+    "buffer-indexof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -2517,6 +2636,43 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
+    "cacache": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.3.0.tgz",
+      "integrity": "sha512-Vbi8J1XfC8v+FbQ6QkOtKXsHpPnB0i9uMeYFJoj40EbdOsEqWB3DPpNjfsnYBkqOPYA8UvrqH6FZPpBP0zdN7g==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "chownr": "1.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lru-cache": "4.1.1",
+        "mississippi": "1.3.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.6.1",
+        "ssri": "4.1.6",
+        "unique-filename": "1.1.0",
+        "y18n": "3.2.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -2531,6 +2687,16 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
+      }
     },
     "camelcase": {
       "version": "1.2.1",
@@ -2616,6 +2782,12 @@
       "integrity": "sha1-6wH07YWsUgqPTZMrTap00+d7x0Y=",
       "dev": true
     },
+    "ccount": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
+      "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok=",
+      "dev": true
+    },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -2659,6 +2831,30 @@
         }
       }
     },
+    "character-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
+      "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco=",
+      "dev": true
+    },
+    "character-entities-html4": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
+      "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA=",
+      "dev": true
+    },
+    "character-entities-legacy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
+      "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8=",
+      "dev": true
+    },
+    "character-reference-invalid": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
+      "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw=",
+      "dev": true
+    },
     "cheerio": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
@@ -2700,6 +2896,12 @@
         "readdirp": "2.1.0"
       }
     },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true
+    },
     "ci-info": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
@@ -2736,6 +2938,32 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
       "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
     },
+    "clean-css": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
+      "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "clean-webpack-plugin": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-0.1.17.tgz",
+      "integrity": "sha512-Bts/V725v8Ijosp4K1cqppQXgXcrohxoMsg0CV2xL4y/vua1G5pAfHEW/eJIiKF+GNNG72mdjbipxMRFEms7yg==",
+      "dev": true,
+      "requires": {
+        "rimraf": "2.6.1"
+      }
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -2761,6 +2989,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "clipboard-copy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-1.2.0.tgz",
+      "integrity": "sha1-9qPeZaiiUvqZP8sqTgz+OqS4dp4=",
       "dev": true
     },
     "clipboardy": {
@@ -2825,6 +3059,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "codemirror": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.31.0.tgz",
+      "integrity": "sha512-LKbMZKoAz7pMmWuSEl253G6yyloSulj1kXfvYv+3n3I8wMiI7QwnCHwKM3Zw5S9ItNV28Layq0/ihQXWmn9T9w==",
+      "dev": true
+    },
+    "collapse-white-space": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
+      "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw=",
       "dev": true
     },
     "color": {
@@ -2892,6 +3138,21 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "common-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/common-dir/-/common-dir-1.0.1.tgz",
+      "integrity": "sha1-T9hyCF68XyYtnMI7D/NLPkV2d/A=",
+      "dev": true,
+      "requires": {
+        "common-sequence": "1.0.2"
+      }
+    },
+    "common-sequence": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
+      "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
       "dev": true
     },
     "common-tags": {
@@ -3082,6 +3343,12 @@
         "xdg-basedir": "3.0.0"
       }
     },
+    "connect-history-api-fallback": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.4.0.tgz",
+      "integrity": "sha1-PbJPlz9LkjsOgvYZzg3wJBHKYj0=",
+      "dev": true
+    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -3138,6 +3405,111 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
+    },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1",
+        "run-queue": "1.0.3"
+      }
+    },
+    "copy-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-eZERim02YjJcepLjrToQMapOoRLfiXewJi9zJON6xXNNJSUhkGzL1L/yFjOufS0KxsnWUzc2szg9t8ZaZKJXAg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "fs-extra": "4.0.2",
+        "glob": "7.1.2",
+        "is-glob": "4.0.0",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "node-dir": "0.1.17"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
     },
     "core-decorators": {
       "version": "0.20.0",
@@ -3520,6 +3892,12 @@
         "array-find-index": "1.0.2"
       }
     },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "dev": true
+    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -3699,12 +4077,28 @@
         "repeating": "2.0.1"
       }
     },
+    "detect-node": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
+      "dev": true
+    },
     "detect-port": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.1.1.tgz",
       "integrity": "sha1-q7JIRaDgUB0qQxPf3pPCZx9rqZg=",
       "dev": true,
       "requires": {
+        "debug": "2.6.9"
+      }
+    },
+    "detect-port-alt": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.3.tgz",
+      "integrity": "sha1-pNLwYddXoDTs83xRQmCph1DysTE=",
+      "dev": true,
+      "requires": {
+        "address": "1.0.2",
         "debug": "2.6.9"
       }
     },
@@ -3725,6 +4119,37 @@
         "randombytes": "2.0.5"
       }
     },
+    "dlv": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.0.tgz",
+      "integrity": "sha1-/uGnxD9jvnXz9nnoUmLaXxAnZKc=",
+      "dev": true
+    },
+    "dns-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+      "dev": true
+    },
+    "dns-packet": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz",
+      "integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
+      "dev": true,
+      "requires": {
+        "ip": "1.1.5",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "dns-txt": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+      "dev": true,
+      "requires": {
+        "buffer-indexof": "1.1.1"
+      }
+    },
     "doctrine": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
@@ -3733,6 +4158,23 @@
       "requires": {
         "esutils": "2.0.2",
         "isarray": "1.0.0"
+      }
+    },
+    "dom-converter": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
+      "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
+      "dev": true,
+      "requires": {
+        "utila": "0.3.3"
+      },
+      "dependencies": {
+        "utila": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
+          "integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
+          "dev": true
+        }
       }
     },
     "dom-helpers": {
@@ -3817,6 +4259,18 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
+    "duplexify": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "stream-shift": "1.0.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -3884,6 +4338,15 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
         "iconv-lite": "0.4.19"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -4027,6 +4490,12 @@
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
     },
     "es6-promise": {
       "version": "4.0.5",
@@ -4492,11 +4961,26 @@
         "through": "2.3.8"
       }
     },
+    "eventemitter3": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+      "dev": true
+    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
+    },
+    "eventsource": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+      "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+      "dev": true,
+      "requires": {
+        "original": "1.0.0"
+      }
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -4554,6 +5038,15 @@
       "dev": true,
       "requires": {
         "fill-range": "2.2.3"
+      }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "1.0.1"
       }
     },
     "express": {
@@ -4678,6 +5171,15 @@
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
       "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
       "dev": true
+    },
+    "faye-websocket": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+      "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+      "dev": true,
+      "requires": {
+        "websocket-driver": "0.7.0"
+      }
     },
     "fb-watchman": {
       "version": "2.0.0",
@@ -4826,6 +5328,30 @@
         "locate-path": "2.0.0"
       }
     },
+    "findup": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+      "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
+      "dev": true,
+      "requires": {
+        "colors": "0.6.2",
+        "commander": "2.1.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
+          "dev": true
+        }
+      }
+    },
     "findup-sync": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
@@ -4867,6 +5393,16 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
+    },
+    "flush-write-stream": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -4924,6 +5460,16 @@
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
     "fs-extra": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -4959,6 +5505,18 @@
             "jsonfile": "2.4.0"
           }
         }
+      }
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.3"
       }
     },
     "fs.realpath": {
@@ -5872,6 +6430,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "function.name-polyfill": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/function.name-polyfill/-/function.name-polyfill-1.0.5.tgz",
+      "integrity": "sha1-00m7TiSjJPCBIEVe54oEFCsSV7s=",
+      "dev": true
+    },
     "function.prototype.name": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
@@ -5916,6 +6480,12 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "dev": true
+    },
     "get-port": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.1.0.tgz",
@@ -5941,6 +6511,23 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
+      }
+    },
+    "github-slugger": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.0.tgz",
+      "integrity": "sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "6.1.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+          "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
+          "dev": true
+        }
       }
     },
     "glamor": {
@@ -6029,6 +6616,30 @@
         "process": "0.5.2"
       }
     },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.1",
+        "resolve-dir": "1.0.1"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.4",
+        "is-windows": "1.0.1",
+        "which": "1.3.0"
+      }
+    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -6047,6 +6658,15 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
+      }
+    },
+    "glogg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
       }
     },
     "got": {
@@ -6084,6 +6704,21 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
+    },
+    "gzip-size": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+      "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1"
+      }
+    },
+    "handle-thing": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
       "dev": true
     },
     "handlebars": {
@@ -6202,6 +6837,18 @@
         "sntp": "2.0.2"
       }
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+      "dev": true
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -6235,11 +6882,32 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
+    },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "obuf": "1.1.1",
+        "readable-stream": "2.3.3",
+        "wbuf": "1.7.2"
+      }
     },
     "html-comment-regex": {
       "version": "1.1.1",
@@ -6268,11 +6936,73 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
     },
+    "html-minifier": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.6.tgz",
+      "integrity": "sha512-88FjtKrlak2XjczhxrBomgzV4jmGzM3UnHRBScRkJcmcRum0kb+IwhVAETJ8AVp7j0p3xugjSaw9L+RmI5/QOA==",
+      "dev": true,
+      "requires": {
+        "camel-case": "3.0.0",
+        "clean-css": "4.1.9",
+        "commander": "2.11.0",
+        "he": "1.1.1",
+        "ncname": "1.0.0",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.1.5"
+      },
+      "dependencies": {
+        "uglify-js": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.5.tgz",
+          "integrity": "sha512-tSqlO7/GZHAVSw6mbtJt2kz0ZcUrKUH7Xg92o52aE+gL0r6cXiASZY4dpHqQ7RVGXmoQuPA2qAkG4TkP59f8XA==",
+          "dev": true,
+          "requires": {
+            "commander": "2.11.0",
+            "source-map": "0.6.1"
+          }
+        }
+      }
+    },
     "html-tag-names": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.2.tgz",
       "integrity": "sha1-9lFolkxanIJnXv2ogoddyyqHXCI=",
       "dev": true
+    },
+    "html-webpack-plugin": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
+      "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "html-minifier": "3.5.6",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.4",
+        "pretty-error": "2.1.1",
+        "toposort": "1.0.6"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
     },
     "htmlparser2": {
       "version": "3.9.2",
@@ -6478,6 +7208,12 @@
         }
       }
     },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+      "dev": true
+    },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
@@ -6494,6 +7230,57 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
           "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
+        }
+      }
+    },
+    "http-parser-js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
+      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
+      "dev": true
+    },
+    "http-proxy": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+      "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+      "dev": true,
+      "requires": {
+        "http-proxy": "1.16.2",
+        "is-glob": "3.1.0",
+        "lodash": "4.17.4",
+        "micromatch": "2.3.11"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         }
       }
@@ -6580,6 +7367,12 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
     },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "dev": true
+    },
     "ignore": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
@@ -6591,6 +7384,16 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
       "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
       "dev": true
+    },
+    "import-local": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
+      "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -6707,6 +7510,15 @@
         }
       }
     },
+    "internal-ip": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
+      "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+      "dev": true,
+      "requires": {
+        "meow": "3.7.0"
+      }
+    },
     "interpret": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
@@ -6745,6 +7557,28 @@
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true
+    },
+    "is-alphabetical": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
+      "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg=",
+      "dev": true
+    },
+    "is-alphanumeric": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+      "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
+      "dev": true
+    },
+    "is-alphanumerical": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
+      "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
+      "dev": true,
+      "requires": {
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -6801,6 +7635,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-decimal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
+      "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI=",
       "dev": true
     },
     "is-directory": {
@@ -6874,6 +7714,18 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
+      "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk=",
+      "dev": true
+    },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=",
+      "dev": true
     },
     "is-my-json-valid": {
       "version": "2.16.1",
@@ -6986,6 +7838,12 @@
         "has": "1.0.1"
       }
     },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
@@ -6999,6 +7857,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
+    "is-root": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+      "integrity": "sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU=",
       "dev": true
     },
     "is-stream": {
@@ -7037,6 +7901,30 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-whitespace-character": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz",
+      "integrity": "sha1-muAXbzKCtlRXoZks2whPil+DPjs=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
+      "dev": true
+    },
+    "is-word-character": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.1.tgz",
+      "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs=",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
@@ -7179,6 +8067,12 @@
       "requires": {
         "handlebars": "4.0.11"
       }
+    },
+    "javascript-stringify": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-1.6.0.tgz",
+      "integrity": "sha1-FC0RHzpuPa6PSpr9d9RYVbWpzOM=",
+      "dev": true
     },
     "jest": {
       "version": "20.0.4",
@@ -7916,6 +8810,12 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -7953,6 +8853,58 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jss": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-8.1.0.tgz",
+      "integrity": "sha512-NZ4CNAoPaPlM2rqHxPG5uGQbQEFZ9n1PITn0+wGIdAk2ZtA/F6el0SphLHf8So1Sx6N34hnVFFIuc32/hdsEzw==",
+      "dev": true,
+      "requires": {
+        "is-in-browser": "1.1.3",
+        "warning": "3.0.0"
+      }
+    },
+    "jss-camel-case": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-5.0.0.tgz",
+      "integrity": "sha512-vz11ip5EIlGuevtlUo9xIgiuD+it4Ebbb0+Y4o0A4oA8eOWY4aY7ihi/L7WvkQ54xnGOjUvLZ6nm2VYch2ufYg==",
+      "dev": true
+    },
+    "jss-compose": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jss-compose/-/jss-compose-4.0.0.tgz",
+      "integrity": "sha512-VnsEziD2Lwrfwp10wx39FNybRLW5+RX/E2qQAXPAMbS+nHc0Jf2dC6ZiCfn5FaBGrpzLfIZ9MalTJDx4CQoMAQ==",
+      "dev": true,
+      "requires": {
+        "warning": "3.0.0"
+      }
+    },
+    "jss-default-unit": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-7.0.0.tgz",
+      "integrity": "sha512-U1Oi1h45vFRuISr+g1DQ3Oua7CkNKNs47fTdiT/lHkuBMc6BBDUbPv9IbPPhk9gsEaX45Iy9TX8CAuaHLPCfEA==",
+      "dev": true
+    },
+    "jss-global": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-2.0.0.tgz",
+      "integrity": "sha512-/FSOMp4lF/vg47T/w8kKvL9tu7ka9am8N4izS63W81Qlay9hAq6xe9RxrPxygLpnn4KEb8LNbkKRoUv4SJfQsQ==",
+      "dev": true
+    },
+    "jss-isolate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jss-isolate/-/jss-isolate-4.0.0.tgz",
+      "integrity": "sha512-bVvWcQj+Jeso8yGcYqnw/h5klf8+ur3Ytr7GG4JQj9TDhueJSvxctoATdfbcZiX72897xvdsDE0OjKUYuilNkQ==",
+      "dev": true
+    },
+    "jss-nested": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-5.0.0.tgz",
+      "integrity": "sha512-9Molau+XVpSc6QEco3EC5yXmzeGMc5ZVII8+qy6jD6bvu6Y9mpfGoJ00LalR/n7xr/LC7Cxgs44UQQlLzumMBg==",
+      "dev": true,
+      "requires": {
+        "warning": "3.0.0"
       }
     },
     "jsx-ast-utils": {
@@ -8068,6 +9020,12 @@
       "requires": {
         "uc.micro": "1.0.3"
       }
+    },
+    "listify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
+      "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
+      "dev": true
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -8192,6 +9150,12 @@
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -8308,10 +9272,22 @@
         "chalk": "1.1.3"
       }
     },
+    "loglevel": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.1.tgz",
+      "integrity": "sha1-GJB4yUq5BT7iFaCs2/JCROoPZQI=",
+      "dev": true
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "longest-streak": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.1.tgz",
+      "integrity": "sha1-QtKRtUEeQDZcAOYxk0l+IkcxbjU=",
       "dev": true
     },
     "loose-envify": {
@@ -8331,6 +9307,12 @@
         "currently-unhandled": "0.4.1",
         "signal-exit": "3.0.2"
       }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.0",
@@ -8419,6 +9401,12 @@
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
+    "markdown-escapes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.1.tgz",
+      "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg=",
+      "dev": true
+    },
     "markdown-it": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.0.tgz",
@@ -8430,6 +9418,24 @@
         "linkify-it": "2.0.3",
         "mdurl": "1.0.1",
         "uc.micro": "1.0.3"
+      }
+    },
+    "markdown-table": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.1.tgz",
+      "integrity": "sha1-Sz3ToTPRUYuO8NvHCb8qG0gkvIw=",
+      "dev": true
+    },
+    "markdown-to-jsx": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-5.4.2.tgz",
+      "integrity": "sha1-LLOxzigAkZD2GezIxcixcUM/tWo=",
+      "dev": true,
+      "requires": {
+        "lodash.get": "4.4.2",
+        "prop-types": "15.6.0",
+        "remark-parse": "4.0.0",
+        "unified": "6.1.5"
       }
     },
     "markdownlint": {
@@ -8513,6 +9519,16 @@
             "safe-buffer": "5.1.1"
           }
         }
+      }
+    },
+    "mdast-util-compact": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
+      "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
+      "dev": true,
+      "requires": {
+        "unist-util-modify-children": "1.1.1",
+        "unist-util-visit": "1.1.3"
       }
     },
     "mdurl": {
@@ -8813,6 +9829,24 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
+    "mississippi": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
+      "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.5.0",
+        "duplexify": "3.5.1",
+        "end-of-stream": "1.4.0",
+        "flush-write-stream": "1.0.2",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "1.0.2",
+        "pumpify": "1.3.5",
+        "stream-each": "1.2.2",
+        "through2": "2.0.3"
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -8828,10 +9862,40 @@
       "integrity": "sha1-zz2C0YwMp/RY2PKiQIF7PcflSgE=",
       "dev": true
     },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1",
+        "run-queue": "1.0.3"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "multicast-dns": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
+      "integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
+      "dev": true,
+      "requires": {
+        "dns-packet": "1.2.2",
+        "thunky": "0.1.0"
+      }
+    },
+    "multicast-dns-service-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
     "mute-stream": {
@@ -8864,11 +9928,29 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ncname": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+      "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
+      "dev": true,
+      "requires": {
+        "xml-char-classes": "1.0.0"
+      }
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "1.1.4"
+      }
     },
     "node-dir": {
       "version": "0.1.17",
@@ -8887,6 +9969,12 @@
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
       }
+    },
+    "node-forge": {
+      "version": "0.6.33",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
+      "integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw=",
+      "dev": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -9152,6 +10240,12 @@
         "has": "1.0.1"
       }
     },
+    "obuf": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
+      "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4=",
+      "dev": true
+    },
     "office-ui-fabric-react": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.1.0.tgz",
@@ -9205,6 +10299,15 @@
       "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
       "dev": true
     },
+    "opn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
+      "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "1.1.0"
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -9247,6 +10350,27 @@
         "cli-cursor": "2.1.0",
         "cli-spinners": "1.1.0",
         "log-symbols": "1.0.2"
+      }
+    },
+    "original": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+      "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+      "dev": true,
+      "requires": {
+        "url-parse": "1.0.5"
+      },
+      "dependencies": {
+        "url-parse": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+          "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+          "dev": true,
+          "requires": {
+            "querystringify": "0.0.4",
+            "requires-port": "1.0.0"
+          }
+        }
       }
     },
     "os": {
@@ -9329,6 +10453,26 @@
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "dev": true,
+      "requires": {
+        "cyclist": "0.2.2",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "2.3.2"
+      }
+    },
     "parse-asn1": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
@@ -9340,6 +10484,20 @@
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
         "pbkdf2": "3.0.14"
+      }
+    },
+    "parse-entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
+      "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
+      "dev": true,
+      "requires": {
+        "character-entities": "1.2.1",
+        "character-entities-legacy": "1.1.1",
+        "character-reference-invalid": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-hexadecimal": "1.0.1"
       }
     },
     "parse-glob": {
@@ -9362,6 +10520,12 @@
       "requires": {
         "error-ex": "1.3.1"
       }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parse5": {
       "version": "1.5.1",
@@ -9753,6 +10917,25 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "immutable": "3.8.2"
+      }
+    },
+    "portfinder": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+      "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
       }
     },
     "postcss": {
@@ -10864,6 +12047,16 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "pretty-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+      "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+      "dev": true,
+      "requires": {
+        "renderkid": "2.0.1",
+        "utila": "0.4.0"
+      }
+    },
     "pretty-format": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
@@ -10922,6 +12115,12 @@
           "dev": true
         }
       }
+    },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
     },
     "promise.prototype.finally": {
       "version": "3.0.1",
@@ -10988,6 +12187,27 @@
         "randombytes": "2.0.5"
       }
     },
+    "pump": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "once": "1.4.0"
+      }
+    },
+    "pumpify": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+      "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+      "dev": true,
+      "requires": {
+        "duplexify": "3.5.1",
+        "inherits": "2.0.3",
+        "pump": "1.0.2"
+      }
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -10999,6 +12219,18 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
+    },
+    "q-i": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/q-i/-/q-i-1.2.0.tgz",
+      "integrity": "sha512-VGQ2dE7+xQ8xLfNddr7K7NnmPr+pvtsxGpxnv7P/4qVAjfHIKgeiU+0eK/5kiA2RmDp98ClT7Mr92Hk4RKTaTA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.0",
+        "dlv": "1.1.0",
+        "is-plain-object": "2.0.4",
+        "stringify-object": "3.2.1"
+      }
     },
     "qs": {
       "version": "6.5.1",
@@ -11026,6 +12258,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "querystringify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+      "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
       "dev": true
     },
     "radium": {
@@ -11158,6 +12396,120 @@
         "prop-types": "15.6.0"
       }
     },
+    "react-codemirror2": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-2.0.2.tgz",
+      "integrity": "sha512-wzsfxnvgGBU3Dftp7G36yjWThm/tN+hzRVZ14sfsiUtTx/od0kmIm9aHU4qavuLKYtN868mCZ7/BOHOVGS03GA==",
+      "dev": true
+    },
+    "react-dev-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-3.1.1.tgz",
+      "integrity": "sha512-xuScoO3RqgGrD15WMtmJf2MoHFu/G886lk8z3vvj87Afxm74UdAyDqtxkCBXvyjUXGRo774HQI7NsSoT9oNXQQ==",
+      "dev": true,
+      "requires": {
+        "address": "1.0.2",
+        "anser": "1.4.1",
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "cross-spawn": "5.1.0",
+        "detect-port-alt": "1.1.3",
+        "escape-string-regexp": "1.0.5",
+        "filesize": "3.5.10",
+        "global-modules": "1.0.0",
+        "gzip-size": "3.0.0",
+        "html-entities": "1.2.1",
+        "inquirer": "3.2.1",
+        "is-root": "1.0.0",
+        "opn": "5.1.0",
+        "recursive-readdir": "2.2.1",
+        "shell-quote": "1.6.1",
+        "sockjs-client": "1.1.4",
+        "strip-ansi": "3.0.1",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "filesize": {
+          "version": "3.5.10",
+          "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.10.tgz",
+          "integrity": "sha1-/I+iPdtO+eXgq24eZPZ5okpWdh8=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
+          "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "2.0.0",
+            "chalk": "2.3.0",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.0.5",
+            "figures": "2.0.0",
+            "lodash": "4.17.4",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx-lite": "4.0.8",
+            "rx-lite-aggregates": "4.0.8",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+              "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "4.5.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
+    },
     "react-docgen": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.19.0.tgz",
@@ -11177,6 +12529,48 @@
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        }
+      }
+    },
+    "react-docgen-displayname-handler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-docgen-displayname-handler/-/react-docgen-displayname-handler-1.0.1.tgz",
+      "integrity": "sha512-L/dtuHUd9ZPovsIpOFem4MJgbe3rFShTWt3mabfJGEbHDUI+y7Htgxrb5hnSPL/UI1Lyw3m1bxXiKdA2faORxg==",
+      "dev": true,
+      "requires": {
+        "recast": "0.12.6"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.9.11",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.11.tgz",
+          "integrity": "sha1-NxF3u1kjL/XOqh0J7lytcFsaWqk=",
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
+        },
+        "recast": {
+          "version": "0.12.6",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.6.tgz",
+          "integrity": "sha1-Sw+4L+sdELO9YtNJQ0Jtmz7TDUw=",
+          "dev": true,
+          "requires": {
+            "ast-types": "0.9.11",
+            "core-js": "2.5.1",
+            "esprima": "4.0.0",
+            "private": "0.1.8",
+            "source-map": "0.5.7"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -11210,6 +12604,15 @@
       "resolved": "https://registry.npmjs.org/react-dom-factories/-/react-dom-factories-1.0.2.tgz",
       "integrity": "sha1-63cFxNs2+1AbOqOP91lhaqD/luA=",
       "dev": true
+    },
+    "react-group": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-group/-/react-group-1.0.5.tgz",
+      "integrity": "sha1-ygfWjLuubZklCCnhwy94JYdpPAc=",
+      "dev": true,
+      "requires": {
+        "prop-types": "15.6.0"
+      }
     },
     "react-html-attributes": {
       "version": "1.4.1",
@@ -11326,6 +12729,194 @@
       "dev": true,
       "requires": {
         "prop-types": "15.6.0"
+      }
+    },
+    "react-styleguidist": {
+      "version": "6.0.31",
+      "resolved": "https://registry.npmjs.org/react-styleguidist/-/react-styleguidist-6.0.31.tgz",
+      "integrity": "sha512-Atpl9gZuh39eZMQlNoRMBs/cATZpJxua8d48AUlC9745Ge5NjAJ+CP0XQscf9RhGc9vUtyxvFlimBY5j9Cym3g==",
+      "dev": true,
+      "requires": {
+        "ast-types": "0.9.14",
+        "buble": "0.15.2",
+        "chalk": "2.3.0",
+        "classnames": "2.2.5",
+        "clean-webpack-plugin": "0.1.17",
+        "clipboard-copy": "1.2.0",
+        "codemirror": "5.31.0",
+        "common-dir": "1.0.1",
+        "copy-webpack-plugin": "4.2.0",
+        "css-loader": "0.28.7",
+        "doctrine": "2.0.0",
+        "es6-object-assign": "1.1.0",
+        "es6-promise": "4.1.1",
+        "escodegen": "1.9.0",
+        "findup": "0.1.5",
+        "function.name-polyfill": "1.0.5",
+        "github-slugger": "1.2.0",
+        "glob": "7.1.2",
+        "glogg": "1.0.0",
+        "highlight.js": "9.12.0",
+        "html-webpack-plugin": "2.30.1",
+        "is-directory": "0.3.1",
+        "javascript-stringify": "1.6.0",
+        "jss": "8.1.0",
+        "jss-camel-case": "5.0.0",
+        "jss-compose": "4.0.0",
+        "jss-default-unit": "7.0.0",
+        "jss-global": "2.0.0",
+        "jss-isolate": "4.0.0",
+        "jss-nested": "5.0.0",
+        "leven": "2.1.0",
+        "listify": "1.0.0",
+        "loader-utils": "1.1.0",
+        "lodash": "4.17.4",
+        "lowercase-keys": "1.0.0",
+        "markdown-to-jsx": "5.4.2",
+        "minimist": "1.2.0",
+        "prop-types": "15.6.0",
+        "q-i": "1.2.0",
+        "react-codemirror2": "2.0.2",
+        "react-dev-utils": "3.1.1",
+        "react-docgen": "3.0.0-beta8",
+        "react-docgen-displayname-handler": "1.0.1",
+        "react-group": "1.0.5",
+        "react-icons": "2.2.7",
+        "remark": "8.0.0",
+        "semver-utils": "1.1.1",
+        "style-loader": "0.18.2",
+        "to-ast": "1.0.0",
+        "type-detect": "4.0.3",
+        "uglifyjs-webpack-plugin": "1.0.0-beta.3",
+        "unist-util-visit": "1.1.3",
+        "webpack-dev-server": "2.9.3",
+        "webpack-merge": "4.1.0",
+        "webpage": "0.3.0"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.9.14",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.14.tgz",
+          "integrity": "sha512-Ebvx7/0lLboCdyEmAw/4GqwBeKIijPveXNiVGhCGCNxc7z26T5he7DC6ARxu8ByKuzUZZcLog+VP8GMyZrBzJw==",
+          "dev": true
+        },
+        "babylon": {
+          "version": "7.0.0-beta.20",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.20.tgz",
+          "integrity": "sha512-kkMTbo/6QmDD+ggF4KaeMLNvf+RfHVtC4mZJcGDZsbQvRqUgG4yWdy6fh3FZbwwLX9BD6PGmAeKN08P5O8pGLQ==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "css-loader": {
+          "version": "0.28.7",
+          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
+          "integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "css-selector-tokenizer": "0.7.0",
+            "cssnano": "3.10.0",
+            "icss-utils": "2.1.0",
+            "loader-utils": "1.1.0",
+            "lodash.camelcase": "4.3.0",
+            "object-assign": "4.1.1",
+            "postcss": "5.2.16",
+            "postcss-modules-extract-imports": "1.1.0",
+            "postcss-modules-local-by-default": "1.2.0",
+            "postcss-modules-scope": "1.1.0",
+            "postcss-modules-values": "1.3.0",
+            "postcss-value-parser": "3.3.0",
+            "source-list-map": "2.0.0"
+          }
+        },
+        "es6-promise": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+          "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "react-docgen": {
+          "version": "3.0.0-beta8",
+          "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-3.0.0-beta8.tgz",
+          "integrity": "sha1-V4iBZs/9BoH6IPoNc+Vp+n/QTDw=",
+          "dev": true,
+          "requires": {
+            "async": "2.5.0",
+            "babel-runtime": "6.26.0",
+            "babylon": "7.0.0-beta.20",
+            "commander": "2.11.0",
+            "doctrine": "2.0.0",
+            "node-dir": "0.1.17",
+            "recast": "0.12.7"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "style-loader": {
+          "version": "0.18.2",
+          "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.18.2.tgz",
+          "integrity": "sha512-WPpJPZGUxWYHWIUMNNOYqql7zh85zGmr84FdTVWq52WTIkqlW9xSxD3QYWi/T31cqn9UNSsietVEgGn2aaSCzw==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.1.0",
+            "schema-utils": "0.3.0"
+          }
+        },
+        "uglifyjs-webpack-plugin": {
+          "version": "1.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.0.0-beta.3.tgz",
+          "integrity": "sha512-4fpQrnoYEuzAwDxI2zLrKMgrknaWu71CpG4XaMRXWWyUJ7yBM4ueIhNNf0/AcKVSUgBpVudi1i9h9lWdfrU7ZQ==",
+          "dev": true,
+          "requires": {
+            "cacache": "9.3.0",
+            "find-cache-dir": "1.0.0",
+            "schema-utils": "0.3.0",
+            "source-map": "0.5.7",
+            "uglify-es": "3.1.5",
+            "webpack-sources": "1.0.1",
+            "worker-farm": "1.5.0"
+          }
+        }
       }
     },
     "react-test-renderer": {
@@ -11450,6 +13041,26 @@
       "dev": true,
       "requires": {
         "resolve": "1.4.0"
+      }
+    },
+    "recursive-readdir": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
+      "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
+      "dev": true,
+      "requires": {
+        "minimatch": "3.0.3"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "redent": {
@@ -11603,6 +13214,68 @@
         }
       }
     },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
+    "remark": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-8.0.0.tgz",
+      "integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
+      "dev": true,
+      "requires": {
+        "remark-parse": "4.0.0",
+        "remark-stringify": "4.0.0",
+        "unified": "6.1.5"
+      }
+    },
+    "remark-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
+      "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
+      "dev": true,
+      "requires": {
+        "collapse-white-space": "1.0.3",
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-whitespace-character": "1.0.1",
+        "is-word-character": "1.0.1",
+        "markdown-escapes": "1.0.1",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "1.1.0",
+        "unherit": "1.1.0",
+        "unist-util-remove-position": "1.1.1",
+        "vfile-location": "2.0.2",
+        "xtend": "4.0.1"
+      }
+    },
+    "remark-stringify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz",
+      "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
+      "dev": true,
+      "requires": {
+        "ccount": "1.0.2",
+        "is-alphanumeric": "1.0.0",
+        "is-decimal": "1.0.1",
+        "is-whitespace-character": "1.0.1",
+        "longest-streak": "2.0.1",
+        "markdown-escapes": "1.0.1",
+        "markdown-table": "1.1.1",
+        "mdast-util-compact": "1.0.1",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.0",
+        "stringify-entities": "1.3.1",
+        "unherit": "1.1.0",
+        "xtend": "4.0.1"
+      }
+    },
     "remarkable": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
@@ -11631,6 +13304,81 @@
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
+    "renderkid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
+      "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
+      "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-converter": "0.1.4",
+        "htmlparser2": "3.3.0",
+        "strip-ansi": "3.0.1",
+        "utila": "0.3.3"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
+          "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
+        },
+        "domutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+          "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+          "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0",
+            "domhandler": "2.1.0",
+            "domutils": "1.1.6",
+            "readable-stream": "1.0.34"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "utila": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
+          "integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
+          "dev": true
+        }
+      }
+    },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -11651,6 +13399,12 @@
       "requires": {
         "is-finite": "1.0.2"
       }
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true
     },
     "request": {
       "version": "2.83.0",
@@ -11747,6 +13501,12 @@
         "resolve-from": "1.0.1"
       }
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
     "resolve": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
@@ -11754,6 +13514,33 @@
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
+      }
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -11813,6 +13600,15 @@
       "dev": true,
       "requires": {
         "is-promise": "2.1.0"
+      }
+    },
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0"
       }
     },
     "rx": {
@@ -11898,6 +13694,21 @@
         "ajv": "5.2.3"
       }
     },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+      "dev": true
+    },
+    "selfsigned": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz",
+      "integrity": "sha1-v4y3uDJWxFUeMTR8YxF3jbme7FI=",
+      "dev": true,
+      "requires": {
+        "node-forge": "0.6.33"
+      }
+    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -11912,6 +13723,12 @@
       "requires": {
         "semver": "5.4.1"
       }
+    },
+    "semver-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz",
+      "integrity": "sha1-J9kv7DTSfPpCcH07QNAlrphV8t8=",
+      "dev": true
     },
     "send": {
       "version": "0.16.1",
@@ -12088,6 +13905,21 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.2",
+        "mime-types": "2.1.17",
+        "parseurl": "1.3.2"
+      }
+    },
     "serve-static": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
@@ -12224,6 +14056,47 @@
         "hoek": "4.2.0"
       }
     },
+    "sockjs": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
+      "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "0.10.0",
+        "uuid": "2.0.3"
+      },
+      "dependencies": {
+        "faye-websocket": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+          "dev": true,
+          "requires": {
+            "websocket-driver": "0.7.0"
+          }
+        },
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
+        }
+      }
+    },
+    "sockjs-client": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+      "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "eventsource": "0.1.6",
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.1.9"
+      }
+    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -12262,6 +14135,12 @@
         }
       }
     },
+    "sparkles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+      "dev": true
+    },
     "spawn-command": {
       "version": "0.0.2-1",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
@@ -12288,6 +14167,35 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
+    },
+    "spdy": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+      "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.1",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.0.20"
+      }
+    },
+    "spdy-transport": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
+      "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.1",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "wbuf": "1.7.2"
+      }
     },
     "split": {
       "version": "0.3.3",
@@ -12319,6 +14227,21 @@
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
       }
+    },
+    "ssri": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+      "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "state-toggle": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.0.tgz",
+      "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU=",
+      "dev": true
     },
     "statuses": {
       "version": "1.3.1",
@@ -12362,6 +14285,16 @@
         "duplexer": "0.1.1"
       }
     },
+    "stream-each": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "stream-shift": "1.0.0"
+      }
+    },
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
@@ -12374,6 +14307,12 @@
         "to-arraybuffer": "1.0.1",
         "xtend": "4.0.1"
       }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -12481,6 +14420,29 @@
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
+      }
+    },
+    "stringify-entities": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
+      "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
+      "dev": true,
+      "requires": {
+        "character-entities-html4": "1.1.1",
+        "character-entities-legacy": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-hexadecimal": "1.0.1"
+      }
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
       }
     },
     "stringstream": {
@@ -12980,6 +14942,22 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "thunky": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
+      "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4=",
+      "dev": true
+    },
     "time-stamp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
@@ -13022,10 +15000,40 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
+    "to-ast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-ast/-/to-ast-1.0.0.tgz",
+      "integrity": "sha1-DEoxyMmO396arwGSx5S0yLEe4oc=",
+      "dev": true,
+      "requires": {
+        "ast-types": "0.7.8",
+        "esprima": "2.7.3"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.7.8",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
+          "dev": true
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        }
+      }
+    },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
+    "toposort": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
+      "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=",
       "dev": true
     },
     "tough-cookie": {
@@ -13049,6 +15057,12 @@
       "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
       "dev": true
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -13059,6 +15073,18 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
+      "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ=",
+      "dev": true
+    },
+    "trough": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.1.tgz",
+      "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y=",
       "dev": true
     },
     "tryit": {
@@ -13283,6 +15309,12 @@
         "prelude-ls": "1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "dev": true
+    },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
@@ -13315,6 +15347,16 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
       "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI=",
       "dev": true
+    },
+    "uglify-es": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.5.tgz",
+      "integrity": "sha512-l2PqhvUNmD5pOKiHMuE8TmlvvsghxvLcg+ffcg/obRn/qm0fXf+1Mi8N7tZZIi6zxQS+PbIvq39VCYxmK0QMYA==",
+      "dev": true,
+      "requires": {
+        "commander": "2.11.0",
+        "source-map": "0.6.1"
+      }
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -13385,6 +15427,31 @@
       "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
       "dev": true
     },
+    "unherit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
+      "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "unified": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.5.tgz",
+      "integrity": "sha1-cWk3hyYhpjE15iztLzrGoGPG+4c=",
+      "dev": true,
+      "requires": {
+        "bail": "1.0.2",
+        "extend": "3.0.1",
+        "is-plain-obj": "1.1.0",
+        "trough": "1.0.1",
+        "vfile": "2.2.0",
+        "x-is-function": "1.0.4",
+        "x-is-string": "0.1.0"
+      }
+    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -13406,6 +15473,24 @@
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
+    "unique-filename": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+      "dev": true,
+      "requires": {
+        "unique-slug": "2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "0.1.4"
+      }
+    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
@@ -13414,6 +15499,36 @@
       "requires": {
         "crypto-random-string": "1.0.0"
       }
+    },
+    "unist-util-modify-children": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.1.tgz",
+      "integrity": "sha1-ZtfmpEnm9nIguXarPLi166w55R0=",
+      "dev": true,
+      "requires": {
+        "array-iterate": "1.1.1"
+      }
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz",
+      "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "1.1.3"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz",
+      "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw=",
+      "dev": true
+    },
+    "unist-util-visit": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.1.3.tgz",
+      "integrity": "sha1-7CaOcxudJ3p5pbWqBkOZDkBdYAs=",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.1",
@@ -13448,6 +15563,12 @@
         "semver-diff": "2.1.0",
         "xdg-basedir": "3.0.0"
       }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
     },
     "url": {
       "version": "0.11.0",
@@ -13485,6 +15606,24 @@
         }
       }
     },
+    "url-parse": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+      "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+      "dev": true,
+      "requires": {
+        "querystringify": "1.0.0",
+        "requires-port": "1.0.0"
+      },
+      "dependencies": {
+        "querystringify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+          "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+          "dev": true
+        }
+      }
+    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -13515,6 +15654,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utila": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
     "utils-merge": {
@@ -13579,6 +15724,23 @@
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
       }
+    },
+    "vfile": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.2.0.tgz",
+      "integrity": "sha1-zkek+zNZIrIz5TXbD32BIdj87U4=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "1.1.1"
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.2.tgz",
+      "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU=",
+      "dev": true
     },
     "vlq": {
       "version": "0.2.3",
@@ -13664,6 +15826,15 @@
         "graceful-fs": "4.1.11"
       }
     },
+    "wbuf": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
+      "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
+      "dev": true,
+      "requires": {
+        "minimalistic-assert": "1.0.0"
+      }
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -13721,6 +15892,254 @@
         "time-stamp": "2.0.0"
       }
     },
+    "webpack-dev-server": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.3.tgz",
+      "integrity": "sha512-bwq7sj452FRH+oVfgOA8xXKkLYPTNsYB4dQ0Jhz3ydjNJ9MvhpGJtehFW8Z0cEcwNkRRiF4aYbReiSGQ4pbS1w==",
+      "dev": true,
+      "requires": {
+        "ansi-html": "0.0.7",
+        "array-includes": "3.0.3",
+        "bonjour": "3.5.0",
+        "chokidar": "1.7.0",
+        "compression": "1.7.1",
+        "connect-history-api-fallback": "1.4.0",
+        "debug": "3.1.0",
+        "del": "3.0.0",
+        "express": "4.16.2",
+        "html-entities": "1.2.1",
+        "http-proxy-middleware": "0.17.4",
+        "import-local": "0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "1.1.5",
+        "loglevel": "1.5.1",
+        "opn": "5.1.0",
+        "portfinder": "1.0.13",
+        "selfsigned": "1.10.1",
+        "serve-index": "1.9.1",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "3.4.7",
+        "strip-ansi": "3.0.1",
+        "supports-color": "4.5.0",
+        "webpack-dev-middleware": "1.12.0",
+        "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "del": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+          "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+          "dev": true,
+          "requires": {
+            "globby": "6.1.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.0",
+            "p-map": "1.2.0",
+            "pify": "3.0.0",
+            "rimraf": "2.6.1"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
+        }
+      }
+    },
     "webpack-hot-middleware": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.20.0.tgz",
@@ -13731,6 +16150,23 @@
         "html-entities": "1.2.1",
         "querystring": "0.2.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "webpack-merge": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.0.tgz",
+      "integrity": "sha1-atciI7PguDflMeRZfBmfkJNhUR4=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
       }
     },
     "webpack-sources": {
@@ -13750,6 +16186,28 @@
           "dev": true
         }
       }
+    },
+    "webpage": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/webpage/-/webpage-0.3.0.tgz",
+      "integrity": "sha1-FcjJnoIrSZ6Zga5odlObQjRIuOc=",
+      "dev": true
+    },
+    "websocket-driver": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "dev": true,
+      "requires": {
+        "http-parser-js": "0.4.9",
+        "websocket-extensions": "0.1.2"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
+      "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=",
+      "dev": true
     },
     "whatwg-encoding": {
       "version": "1.0.1",
@@ -13905,10 +16363,28 @@
         "signal-exit": "3.0.2"
       }
     },
+    "x-is-function": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/x-is-function/-/x-is-function-1.0.4.tgz",
+      "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4=",
+      "dev": true
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+      "dev": true
+    },
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
+    },
+    "xml-char-classes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
+      "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0=",
       "dev": true
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "raw-loader": "=0.5.1",
     "react": "=15.5.4",
     "react-dom": "=15.5.4",
+    "react-styleguidist": "^6.0.31",
     "react-test-renderer": "=15.5.4",
     "rimraf": "=2.6.1",
     "serve": "=5.1.4",


### PR DESCRIPTION
Adds react-styleguidist dependency, the minimal change to break visual diff runs. Other new dependencies from that branch did not cause any problems.

https://github.com/Microsoft/YamUI/pull/84
@unindented