### PR TITLE
font-display: swap instead of optional

### DIFF
--- a/src/css/font-face.css
+++ b/src/css/font-face.css
@@ -17,7 +17,7 @@
         url('https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-regular.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
 }
 
 
@@ -35,7 +35,7 @@
         url('https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-light.ttf') format('truetype');
   font-weight: 100;
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Segoe UI WestEuropean';
@@ -45,7 +45,7 @@
         url('https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-semilight.ttf') format('truetype');
   font-weight: 200;
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Segoe UI WestEuropean';
@@ -55,5 +55,5 @@
         url('https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-semibold.ttf') format('truetype');
   font-weight: 600;
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
 }


### PR DESCRIPTION
# *font-display: swap instead of optional*

Follow up on https://github.com/Microsoft/YamUI/pull/85, puts `swap` on `font-display` instead of `optional`.

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [ ] Component visual reference files are up-to-date.
* [x] Component is unit tested.

No component/functional changes.
