### PR TITLE
Change script back to /bin/bash

### DIFF
--- a/config/travis/build
+++ b/config/travis/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 set -o pipefail


### PR DESCRIPTION
`bin/sh` is not pointing to bash, so `set -o` fails.