### PR TITLE
[improvement] Update Clickable type to be button

### DIFF
--- a/src/components/Clickable/Clickable.tsx
+++ b/src/components/Clickable/Clickable.tsx
@@ -35,7 +35,13 @@ export default class Clickable extends React.PureComponent<ClickableProps, {}> {
     const { ariaLabel, title, onClick, children } = this.props;
 
     return (
-      <button className={this.getClasses()} aria-label={ariaLabel} title={title} onClick={onClick}>
+      <button
+        className={this.getClasses()}
+        aria-label={ariaLabel}
+        title={title}
+        onClick={onClick}
+        type="button"
+      >
         {children}
       </button>
     );

--- a/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
+++ b/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<Clickable /> when ariaLabel is passed matches its snapshot 1`] = `
 <button
   aria-label="aria label content"
   className="y-clickable"
+  type="button"
 >
   clickable content
 </button>
@@ -12,6 +13,7 @@ exports[`<Clickable /> when ariaLabel is passed matches its snapshot 1`] = `
 exports[`<Clickable /> when block is true matches its snapshot 1`] = `
 <button
   className="y-clickable y-clickable__block"
+  type="button"
 >
   clickable content
 </button>
@@ -21,6 +23,7 @@ exports[`<Clickable /> when title is passed matches its snapshot 1`] = `
 <button
   className="y-clickable"
   title="extra browser tooltip content"
+  type="button"
 >
   clickable content
 </button>
@@ -29,6 +32,7 @@ exports[`<Clickable /> when title is passed matches its snapshot 1`] = `
 exports[`<Clickable /> with additional className matches its snapshot 1`] = `
 <button
   className="y-clickable TEST_CLASSNAME"
+  type="button"
 >
   clickable content
 </button>
@@ -37,6 +41,7 @@ exports[`<Clickable /> with additional className matches its snapshot 1`] = `
 exports[`<Clickable /> with default options matches its snapshot 1`] = `
 <button
   className="y-clickable"
+  type="button"
 >
   clickable content
 </button>


### PR DESCRIPTION
Currently using Clickable inside of forms will cause a submission as there is no type set, defaulting to ‘submit’ (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button)

# *Pull request subject*

*Describe the change you are making.*

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [x] Component visual reference files are up-to-date.
* [x] Component is unit tested.
