### PR TITLE
Fix import paths in styleguide

### DIFF
--- a/config/styleguide/config.js
+++ b/config/styleguide/config.js
@@ -7,7 +7,7 @@ const webpackConfig = require('./webpack.config.js');
 const getComponentPathLine = (componentPath) => {
   const ext = path.extname(componentPath);
   const name = path.basename(componentPath, ext);
-  const dir = path.dirname(componentPath).replace(/^src\//, 'yamui/dist/');
+  const dir = path.dirname(componentPath).replace(/.*\/src\//, 'yamui/dist/');
   return `import ${name} from '${dir}';`;
 };
 


### PR DESCRIPTION
Import paths were not being generated properly after I moved the config file.

Here's what it was:

![screen shot 2017-11-07 at 10 07 51](https://user-images.githubusercontent.com/69485/32509983-e6f2b570-c3a3-11e7-93a8-1dc07902da01.png)

Here's what it should be:

![screen shot 2017-11-07 at 10 07 56](https://user-images.githubusercontent.com/69485/32509991-edcb051e-c3a3-11e7-88eb-f0874e1dc5ca.png)
