### PR TITLE
Delay rendering of examples until they intersect the viewport

### DIFF
--- a/config/styleguide/config.js
+++ b/config/styleguide/config.js
@@ -56,6 +56,6 @@ module.exports = {
   serverPort: 5555,
   styleguideDir: path.resolve(root, 'build/docs'),
   styleguideComponents: {
-    Wrapper: path.resolve(root, 'src/components/Fabric'),
+    Wrapper: path.resolve(root, 'src/demos/ExampleWrapper'),
   },
 };

--- a/src/demos/ExampleWrapper/ExampleWrapper.tsx
+++ b/src/demos/ExampleWrapper/ExampleWrapper.tsx
@@ -1,0 +1,52 @@
+/*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
+import * as React from 'react';
+import Fabric from '../../../src/components/Fabric';
+
+export interface ExampleWrapperState {
+  visible: boolean;
+}
+
+export default class ExampleWrapper extends React.PureComponent<{}, ExampleWrapperState> {
+  private observer: IntersectionObserver;
+
+  constructor() {
+    super();
+
+    this.state = {
+      visible: !this.supportsIntersectionObserver(),
+    };
+
+    this.observeElement = this.observeElement.bind(this);
+    this.handleObservedElement = this.handleObservedElement.bind(this);
+  }
+
+  render() {
+    const { visible } = this.state;
+
+    return (
+      <div ref={this.observeElement}>
+        {visible && <Fabric>{this.props.children}</Fabric>}
+      </div>
+    );
+  }
+
+  private supportsIntersectionObserver() {
+    return 'IntersectionObserver' in window;
+  }
+
+  private observeElement(element: HTMLElement | null) {
+    if (!this.supportsIntersectionObserver() || this.observer != null || element == null) {
+      return;
+    }
+
+    this.observer = new IntersectionObserver(this.handleObservedElement, { threshold: 0.1 });
+    this.observer.observe(element);
+  }
+
+  private handleObservedElement(entries: IntersectionObserverEntry[]) {
+    const pixels = entries.reduce((memo, entry) => memo + entry.intersectionRatio, 0);
+    if (pixels > 0) {
+      this.setState({ visible: true });
+    }
+  }
+}

--- a/src/demos/ExampleWrapper/index.ts
+++ b/src/demos/ExampleWrapper/index.ts
@@ -1,0 +1,3 @@
+/*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
+export { default } from './ExampleWrapper';
+export * from './ExampleWrapper';


### PR DESCRIPTION
When our styleguide page gets loaded, all callouts render even though they're not in view, and it looks janky.

![screen shot 2017-11-07 at 11 49 55](https://user-images.githubusercontent.com/69485/32514507-0d03cfde-c3b2-11e7-9963-34702e302b50.png)

I'm proposing we don't render an example until it enters the viewport, by using `IntersectionObserver`.