### PR TITLE
Do not use ES6 features in action, as it doesn't get transpiled

### DIFF
--- a/config/styleguide/context/action.js
+++ b/config/styleguide/context/action.js
@@ -1,5 +1,8 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
-module.exports = msg => (...args) => {
-  // eslint-disable-next-line no-console
-  console.log(msg, ...args);
+/* eslint-disable */
+module.exports = function(msg) {
+  return function() {
+    console.log(msg, arguments);
+  };
 };
+/* eslint-enable */


### PR DESCRIPTION
The arrow function was ending up in the bundle, causing IE to choke.