### PR TITLE
Move from PureComponent to Component

### DIFF
--- a/config/yo/generator-component/app/templates/Component.tsx
+++ b/config/yo/generator-component/app/templates/Component.tsx
@@ -19,7 +19,7 @@ export interface <%= name %>Props extends BaseComponentProps {
  * Describe what `<%= name %>` does. This will also appear as part of this component's
  * documentation.
  */
-export default class <%= name %> extends React.PureComponent<<%= name %>Props, {}> {
+export default class <%= name %> extends React.Component<<%= name %>Props, {}> {
   static defaultProps = {
     type: <%= name %>Type.BLACK,
   };

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -55,7 +55,7 @@ export interface AvatarProps extends BaseComponentProps {
 /**
  * An `Avatar` shows a thumbnail representation of both an individual or group.
  */
-export default class Avatar extends React.PureComponent<AvatarProps, {}> {
+export default class Avatar extends React.Component<AvatarProps, {}> {
   static defaultProps: Partial<AvatarProps> = {
     borderType: AvatarBorderType.ROUND,
     size: AvatarSize.MEDIUM,

--- a/src/components/Block/Block.tsx
+++ b/src/components/Block/Block.tsx
@@ -52,7 +52,7 @@ interface BlockStyles {
  * the `4px` vertical rhythm. It's also the primary place you should set `textSize` in your UIs,
  * providing enumerated options for the supported `font-size`/`line-height` combinations.
  */
-export default class Block extends React.PureComponent<BlockProps, {}> {
+export default class Block extends React.Component<BlockProps, {}> {
   render() {
     const { children } = this.props;
 

--- a/src/components/Button/Button.md
+++ b/src/components/Button/Button.md
@@ -489,7 +489,7 @@ Loading button:
 ```js { "props": { "data-example": "loading" } }
 const { ButtonStatus } = require('.');
 
-class LoadingButton extends React.PureComponent {
+class LoadingButton extends React.Component {
   constructor(props) {
     super(props);
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -119,7 +119,7 @@ export type ButtonProps = RegularButtonProps | LoadingButtonProps | LinkButtonPr
 /**
  * A `Button` allows a user to take an action.
  */
-export default class Button extends React.PureComponent<ButtonProps, {}> {
+export default class Button extends React.Component<ButtonProps, {}> {
   static propTypes = {
     // TypeScript does not support negated types, so we need to do a runtime validation instead.
     href(props: LinkButtonProps, propName: string, componentName: string) {

--- a/src/components/Clickable/Clickable.tsx
+++ b/src/components/Clickable/Clickable.tsx
@@ -38,7 +38,7 @@ export interface ClickableProps extends NestableBaseComponentProps {
  * like a link by default, but can also be unstyled. Under the hood `Clickable` simply wraps
  * content in a `button` element.
  */
-export default class Clickable extends React.PureComponent<ClickableProps, {}> {
+export default class Clickable extends React.Component<ClickableProps, {}> {
   render() {
     const { ariaLabel, title, unstyled, onClick, children } = this.props;
 

--- a/src/components/Dropdown/Dropdown.md
+++ b/src/components/Dropdown/Dropdown.md
@@ -15,7 +15,7 @@ const options = [
   { key: 'C', text: 'Option C' },
 ];
 
-class ControlledDropdown extends React.PureComponent {
+class ControlledDropdown extends React.Component {
   constructor() {
     super();
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -41,7 +41,7 @@ export interface DropdownProps extends BaseComponentProps {
  * A `Dropdown` is a list in which the selected item is always visible, and the others are visible
  * on demand by clicking a button.
  */
-export default class Dropdown extends React.PureComponent<DropdownProps, {}> {
+export default class Dropdown extends React.Component<DropdownProps, {}> {
   render() {
     const { label, options, placeHolder, selectedKey } = this.props;
 

--- a/src/components/FakeLink/FakeLink.tsx
+++ b/src/components/FakeLink/FakeLink.tsx
@@ -12,10 +12,10 @@ export { FakeLinkProps };
  * component). It is meant to be nested within unstyled `NavigationLink` or `Clickable`
  * components, allowing an entire block of content to be an accessible tabbable element while
  * still showing individual nested "links" for sighted users.
- * 
+ *
  * NOTE: If you are looking for click interaction please see [Clickable](#clickable).
  */
-export default class FakeLink extends React.PureComponent<FakeLinkProps, {}> {
+export default class FakeLink extends React.Component<FakeLinkProps, {}> {
   render() {
     const { className, children } = this.props;
 

--- a/src/components/FixedGrid/FixedGridColumn.tsx
+++ b/src/components/FixedGrid/FixedGridColumn.tsx
@@ -31,7 +31,7 @@ interface ColumnStyles {
  * A `FixedGridColumn` represents each column inside a `FixedGrid`. It should be wrapped in a
  * `FixedGridRow`.
  */
-export default class FixedGridColumn extends React.PureComponent<FixedGridColumnProps, {}> {
+export default class FixedGridColumn extends React.Component<FixedGridColumnProps, {}> {
   render() {
     const { children, verticalAlign } = this.props;
 

--- a/src/components/FixedGrid/FixedGridRow.tsx
+++ b/src/components/FixedGrid/FixedGridRow.tsx
@@ -23,7 +23,7 @@ export { GutterSize };
 /**
  * A `FixedGridRow` represents each row inside a `FixedGrid`. It should wrap `FixedGridColumn`s.
  */
-export default class FixedGridRow extends React.PureComponent<FixedGridRowProps, {}> {
+export default class FixedGridRow extends React.Component<FixedGridRowProps, {}> {
   static defaultProps = {
     gutterSize: GutterSize.SMALL,
   };

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -53,7 +53,7 @@ export interface HeadingProps extends NestableBaseComponentProps {
  * override its visual styling to match a different level with `size`. Set `size="none"`
  * to render the heading as unstyled inline text.
  */
-export default class Heading extends React.PureComponent<HeadingProps, {}> {
+export default class Heading extends React.Component<HeadingProps, {}> {
   render() {
     const TagName = `h${this.props.level}`;
 

--- a/src/components/HorizontalList/HorizontalList.tsx
+++ b/src/components/HorizontalList/HorizontalList.tsx
@@ -15,7 +15,7 @@ export interface HorizontalListProps extends NestableBaseComponentProps {
 /**
  * A `HorizontalList` displays a horizontal list of evenly spaced items.
  */
-export default class HorizontalList extends React.PureComponent<HorizontalListProps, {}> {
+export default class HorizontalList extends React.Component<HorizontalListProps, {}> {
   static defaultProps = {
     align: 'left',
   };

--- a/src/components/HorizontalList/HorizontalListItem.tsx
+++ b/src/components/HorizontalList/HorizontalListItem.tsx
@@ -11,7 +11,7 @@ export { HorizontalListItemProps };
 /**
  * Each of the items nested within a `HorizontalList` component.
  */
-export default class HorizontalListItem extends React.PureComponent<HorizontalListItemProps, {}> {
+export default class HorizontalListItem extends React.Component<HorizontalListItemProps, {}> {
   render() {
     const { children } = this.props;
 

--- a/src/components/Hovercard/HovercardHeader.tsx
+++ b/src/components/Hovercard/HovercardHeader.tsx
@@ -10,7 +10,7 @@ export { HovercardHeaderProps };
 /**
  * Header of a `Hovercard` component. Used to maintain a consistent layout.
  */
-export default class HovercardHeader extends React.PureComponent<HovercardHeaderProps, {}> {
+export default class HovercardHeader extends React.Component<HovercardHeaderProps, {}> {
   render() {
     const { className, children } = this.props;
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -43,7 +43,7 @@ interface IconStyles {
 /**
  * An `Icon` renders an SVG icon.
  */
-export default class Icon extends React.PureComponent<IconProps, {}> {
+export default class Icon extends React.Component<IconProps, {}> {
   public render() {
     const { icon } = this.props;
     const CurrentIcon = icons[icon];
@@ -73,7 +73,7 @@ export default class Icon extends React.PureComponent<IconProps, {}> {
 
   private getInlineStyles() {
     const { color, size } = this.props;
-    
+
     const styles: IconStyles = {};
 
     if (size) {

--- a/src/components/Image/Image.md
+++ b/src/components/Image/Image.md
@@ -161,7 +161,7 @@ const badImage = 'logoNotFound.png';
 const yammerLogo = 'logoFallback.png';
 const yammerLogoDescription = 'Yammer "y" logo';
 
-class StateChangeDemo extends React.PureComponent {
+class StateChangeDemo extends React.Component {
   constructor() {
     super();
 

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -63,7 +63,7 @@ export interface ImageProps extends BaseComponentProps {
  * applied to the wrapper `div`, and the image will get scaled/positioned within the wrapper
  * depending on which props you provide.
  */
-export default class Image extends React.PureComponent<ImageProps, {}> {
+export default class Image extends React.Component<ImageProps, {}> {
   static defaultProps: Partial<ImageProps> = {
     fullWidth: false,
     shouldFadeIn: false,

--- a/src/components/MediaObject/MediaObject.tsx
+++ b/src/components/MediaObject/MediaObject.tsx
@@ -56,7 +56,7 @@ const ImageWidthMap = {
  * image area, and pieces of text content, are passed in as props, with size and layout determined
  * by the `size` prop.
  */
-export default class MediaObject extends React.PureComponent<MediaObjectProps, {}> {
+export default class MediaObject extends React.Component<MediaObjectProps, {}> {
   render() {
     const {
       size,

--- a/src/components/MediaObject/MediaObjectExtra.tsx
+++ b/src/components/MediaObject/MediaObjectExtra.tsx
@@ -8,7 +8,7 @@ import Text, { TextColor } from '../Text';
 
 export { MediaObjectExtraProps };
 
-export default class MediaObjectExtra extends React.PureComponent<MediaObjectExtraProps, {}> {
+export default class MediaObjectExtra extends React.Component<MediaObjectExtraProps, {}> {
   render() {
     const { children } = this.props;
 

--- a/src/components/MediaObject/MediaObjectMetadata.tsx
+++ b/src/components/MediaObject/MediaObjectMetadata.tsx
@@ -18,7 +18,7 @@ export interface MediaObjectMetadataProps {
   size: MediaObjectSize;
 }
 
-export default class MediaObjectMetadata extends React.PureComponent<MediaObjectMetadataProps, {}> {
+export default class MediaObjectMetadata extends React.Component<MediaObjectMetadataProps, {}> {
   render() {
     const { size, children } = this.props;
 

--- a/src/components/MediaObject/MediaObjectTitle.tsx
+++ b/src/components/MediaObject/MediaObjectTitle.tsx
@@ -25,7 +25,7 @@ export interface MediaObjectTitleProps {
   size: MediaObjectSize;
 }
 
-export default class MediaObjectTitle extends React.PureComponent<MediaObjectTitleProps, {}> {
+export default class MediaObjectTitle extends React.Component<MediaObjectTitleProps, {}> {
   render() {
     const { size, children } = this.props;
 

--- a/src/components/MessageBar/MessageBar.tsx
+++ b/src/components/MessageBar/MessageBar.tsx
@@ -27,7 +27,7 @@ export interface MessageBarProps extends NestableBaseComponentProps {
  * A `MessageBar` displays relevant status information. You can use a `MessageBar` to tell the user
  * about a situation, and optionally provide actions for them to take.
  */
-export default class MessageBar extends React.PureComponent<MessageBarProps, {}> {
+export default class MessageBar extends React.Component<MessageBarProps, {}> {
   static defaultProps = {
     type: MessageBarType.INFO,
   };

--- a/src/components/NavigationLink/NavigationLink.tsx
+++ b/src/components/NavigationLink/NavigationLink.tsx
@@ -31,7 +31,7 @@ export interface NavigationLinkProps extends NestableBaseComponentProps {
 /**
  * A `NavigationLink` renders an `a` tag for navigation between web pages.
  */
-export default class NavigationLink extends React.PureComponent<NavigationLinkProps, {}> {
+export default class NavigationLink extends React.Component<NavigationLinkProps, {}> {
   render() {
     const { href, newWindow, title, children } = this.props;
     const target = newWindow ? '_blank' : undefined;

--- a/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { BaseComponentProps } from '../../util/BaseComponent/props';
 import {
-  ProgressIndicator as OfficeFabricProgressIndicator, 
+  ProgressIndicator as OfficeFabricProgressIndicator,
 } from 'office-ui-fabric-react/lib/ProgressIndicator';
 import './ProgressIndicator.css';
 
@@ -23,7 +23,7 @@ export interface ProgressIndicatorProps extends BaseComponentProps {
  * A `ProgressIndicator` is used to show the progress of an ongoing operation
  * e.g. a file upload.
  */
-export default class ProgressIndicator extends React.PureComponent<ProgressIndicatorProps, {}> {
+export default class ProgressIndicator extends React.Component<ProgressIndicatorProps, {}> {
   render() {
     const { ariaValueText, percentComplete } = this.props;
     return (

--- a/src/components/ScreenreaderText/ScreenreaderText.tsx
+++ b/src/components/ScreenreaderText/ScreenreaderText.tsx
@@ -14,7 +14,7 @@ export { ScreenreaderTextProps };
  * Use this component whenever a screenreader should be able to read aloud additional context for
  * your UI features.
  */
-export default class ScreenreaderText extends React.PureComponent<ScreenreaderTextProps, {}> {
+export default class ScreenreaderText extends React.Component<ScreenreaderTextProps, {}> {
   render() {
     const { className, children } = this.props;
 

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -61,7 +61,7 @@ export interface SpinnerProps extends BaseComponentProps {
  * A `Spinner` is an outline of a circle which animates around itself indicating to the user that
  * things are processing. It is shown when we're unsure how long a task will take.
  */
-export default class Spinner extends React.PureComponent<SpinnerProps, {}> {
+export default class Spinner extends React.Component<SpinnerProps, {}> {
   static defaultProps: Partial<SpinnerProps> = {
     hideText: false,
     color: SpinnerColor.LIGHT,

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -41,7 +41,7 @@ export interface TextProps extends NestableBaseComponentProps {
  * need to own this CSS. This is both a convenience for engineers and a way to enforce consistency
  * of supported text colors and `font-size`/`line-height` combinations.
  */
-export default class Text extends React.PureComponent<TextProps, {}> {
+export default class Text extends React.Component<TextProps, {}> {
   render() {
     const { children } = this.props;
 

--- a/src/demos/ExampleWrapper/ExampleWrapper.tsx
+++ b/src/demos/ExampleWrapper/ExampleWrapper.tsx
@@ -6,7 +6,7 @@ export interface ExampleWrapperState {
   visible: boolean;
 }
 
-export default class ExampleWrapper extends React.PureComponent<{}, ExampleWrapperState> {
+export default class ExampleWrapper extends React.Component<{}, ExampleWrapperState> {
   private observer: IntersectionObserver;
 
   constructor() {

--- a/src/demos/FileHovercard/FileHovercard.tsx
+++ b/src/demos/FileHovercard/FileHovercard.tsx
@@ -32,7 +32,7 @@ export interface FileHovercardProps {
   file: any;
 }
 
-export default class FileHovercard extends React.PureComponent<FileHovercardProps, {}> {
+export default class FileHovercard extends React.Component<FileHovercardProps, {}> {
   render() {
     const { file } = this.props;
 

--- a/src/demos/GroupHovercard/GroupHovercard.tsx
+++ b/src/demos/GroupHovercard/GroupHovercard.tsx
@@ -43,7 +43,7 @@ export interface GroupHovercardProps {
   group: any;
 }
 
-export default class GroupHovercard extends React.PureComponent<GroupHovercardProps, {}> {
+export default class GroupHovercard extends React.Component<GroupHovercardProps, {}> {
   render() {
     const { group } = this.props;
 

--- a/src/demos/MessageReply/MessageReply.tsx
+++ b/src/demos/MessageReply/MessageReply.tsx
@@ -1,7 +1,7 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
 
-export default class MessageReply extends React.PureComponent<{}, {}> {
+export default class MessageReply extends React.Component<{}, {}> {
   render() {
     return (
       <div>

--- a/src/demos/UserHovercard/UserHovercard.tsx
+++ b/src/demos/UserHovercard/UserHovercard.tsx
@@ -29,7 +29,7 @@ export interface UserHovercardProps {
   user: any;
 }
 
-export default class UserHovercard extends React.PureComponent<UserHovercardProps, {}> {
+export default class UserHovercard extends React.Component<UserHovercardProps, {}> {
   render() {
     const { user } = this.props;
 


### PR DESCRIPTION
PureComponents don't play well with `react-router` and its use of
`context`:
https://github.com/ReactTraining/react-router/blob/d1071993e6262bc2e752c79b52a445979ce67111/packages/react-router/docs/guides/blocked-updates.md

Fabric also uses Component for everything.

Proposal is to use Component by default, and only use PureComponent for specific things that need the perf optimization.