### PR TITLE
Extract Callout from Hovercard

### DIFF
--- a/src/components/Callout/Callout.css
+++ b/src/components/Callout/Callout.css
@@ -1,0 +1,8 @@
+/*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
+
+/* Fabric Callout box-shadow override */
+.ms-Callout {
+  box-shadow: 0 0 12px rgba(0, 0, 0, .2)  !important;
+  border: none;
+  border-radius: 1px;
+}

--- a/src/components/Callout/Callout.md
+++ b/src/components/Callout/Callout.md
@@ -1,21 +1,40 @@
 ### Notes for use
 
-Callout is simply exported from Fabric, with some minor YamUI styling. It is meant to be used as a utility component by other YamUI components like Hovercard and Tooltip, you probably don't need to use it directly in your application UIs.
-https://developer.microsoft.com/en-us/fabric#/components/callout
+Callout is simply [exported from Fabric](https://developer.microsoft.com/en-us/fabric#/components/callout), with some minor YamUI styling. It is meant to be used as a utility component by other YamUI components like Hovercard and Tooltip, you probably don't need to use it directly in your application UIs.
+
 
 ### Examples
 
 Basic usage:
 
 ```js
-const visible = true;
+class MyComponent extends React.Component {
+  constructor() {
+    super();
 
-<div>
-  <span className="myTarget">Target</span>
-  {visible && (
-    <Callout target=".myTarget">
-      This message is displayed in the Callout popover!
-    </Callout>
-  )}
-</div>
+    this.state = {
+      visible: false,
+    };
+  }
+
+  render() {
+    const callout = this.state.visible && (
+      <Callout target={this.triggerElement}>
+        <div style={{ padding: '10px' }}>This message is displayed in the Callout popover!</div>
+      </Callout>
+    );
+
+    return (
+      <span>
+        <span ref={node => (this.triggerElement = node)} onClick={() => this.setState({ visible: !this.state.visible })}>
+          {this.props.children}
+        </span>
+        {callout}
+      </span>
+    );
+  }
+}
+
+
+<MyComponent>Click me</MyComponent>
 ```

--- a/src/components/Callout/Callout.md
+++ b/src/components/Callout/Callout.md
@@ -1,0 +1,21 @@
+### Notes for use
+
+Callout is simply exported from Fabric, with some minor YamUI styling. It is meant to be used as a utility component by other YamUI components like Hovercard and Tooltip, you probably don't need to use it directly in your application UIs.
+https://developer.microsoft.com/en-us/fabric#/components/callout
+
+### Examples
+
+Basic usage:
+
+```js
+const visible = true;
+
+<div>
+  <span className="myTarget">Target</span>
+  {visible && (
+    <Callout target=".myTarget">
+      This message is displayed in the Callout popover!
+    </Callout>
+  )}
+</div>
+```

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -1,0 +1,11 @@
+/*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
+import '../../yamui';
+import {
+  Callout,
+  ICalloutProps as CalloutProps,
+  DirectionalHint,
+} from 'office-ui-fabric-react/lib/Callout';
+import './Callout.css';
+
+export default Callout;
+export { CalloutProps, DirectionalHint };

--- a/src/components/Callout/index.ts
+++ b/src/components/Callout/index.ts
@@ -1,0 +1,3 @@
+/*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
+export { default } from './Callout';
+export * from './Callout';

--- a/src/components/Hovercard/Hovercard.css
+++ b/src/components/Hovercard/Hovercard.css
@@ -9,10 +9,3 @@
 .y-hovercard--header {
   border-bottom: 2px solid $borderColor__tertiary;
 }
-
-/* Fabric Callout box-shadow override */
-.ms-Callout {
-  box-shadow: 0 0 12px rgba(0, 0, 0, .2)  !important;
-  border: none;
-  border-radius: 1px;
-}

--- a/src/components/Hovercard/Hovercard.test.tsx
+++ b/src/components/Hovercard/Hovercard.test.tsx
@@ -1,7 +1,7 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
 import { mount, ReactWrapper, shallow, ShallowWrapper } from 'enzyme';
-import { Callout as FabricCallout } from 'office-ui-fabric-react/lib/Callout';
+import Callout from '../Callout';
 import { Key } from '../../util/enums';
 import { Hovercard, HovercardProps, HovercardState, TriggerType } from '.';
 
@@ -30,7 +30,7 @@ describe('<Hovercard />', () => {
       });
 
       it('does not show the hovercard', () => {
-        expect(component.find(FabricCallout).length).toBe(0);
+        expect(component.find(Callout).length).toBe(0);
       });
 
       it('matches its snapshot', () => {
@@ -182,7 +182,7 @@ describe('<Hovercard />', () => {
 
       it('the Hovercard closes after a delay', () => {
         jest.runTimersToTime(500);
-        expect(component.find(FabricCallout).length).toBe(0);
+        expect(component.find(Callout).length).toBe(0);
       });
 
       describe('mousing back in', () => {
@@ -193,7 +193,7 @@ describe('<Hovercard />', () => {
 
         it('prevents the hovercard from closing', () => {
           jest.runTimersToTime(500);
-          expect(component.find(FabricCallout).length).toBe(1);
+          expect(component.find(Callout).length).toBe(1);
         });
 
         describe('and mousing back out', () => {
@@ -203,7 +203,7 @@ describe('<Hovercard />', () => {
 
           it('allows the Hovercard to close', () => {
             jest.runTimersToTime(500);
-            expect(component.find(FabricCallout).length).toBe(0);
+            expect(component.find(Callout).length).toBe(0);
           });
         });
       });
@@ -222,7 +222,7 @@ describe('<Hovercard />', () => {
 
         it('prevents the hovercard from closing', () => {
           jest.runTimersToTime(500);
-          expect(component.find(FabricCallout).length).toBe(1);
+          expect(component.find(Callout).length).toBe(1);
         });
 
         describe('and mousing back out', () => {
@@ -232,7 +232,7 @@ describe('<Hovercard />', () => {
 
           it('allows the Hovercard to close', () => {
             jest.runTimersToTime(500);
-            expect(component.find(FabricCallout).length).toBe(0);
+            expect(component.find(Callout).length).toBe(0);
           });
         });
       });
@@ -245,7 +245,7 @@ describe('<Hovercard />', () => {
       });
 
       it('the Hovercard closes immediately', () => {
-        expect(component.find(FabricCallout).length).toBe(0);
+        expect(component.find(Callout).length).toBe(0);
       });
     });
 
@@ -256,7 +256,7 @@ describe('<Hovercard />', () => {
       });
 
       it('the Hovercard remains open', () => {
-        expect(component.find(FabricCallout).length).toBe(1);
+        expect(component.find(Callout).length).toBe(1);
       });
     });
   });
@@ -272,7 +272,7 @@ describe('<Hovercard />', () => {
     });
 
     it('renders the Hovercard', () => {
-      expect(fullComponent.find(FabricCallout).length).toBe(0);
+      expect(fullComponent.find(Callout).length).toBe(0);
     });
   });
 
@@ -287,7 +287,7 @@ describe('<Hovercard />', () => {
     });
 
     it('renders the Hovercard', () => {
-      expect(fullComponent.find(FabricCallout).length).toBe(1);
+      expect(fullComponent.find(Callout).length).toBe(1);
     });
 
     describe('when a hover out triggers its close timeout', () => {

--- a/src/components/Hovercard/Hovercard.tsx
+++ b/src/components/Hovercard/Hovercard.tsx
@@ -3,7 +3,7 @@ import '../../yamui';
 import * as React from 'react';
 import autobind from 'core-decorators/lib/autobind';
 import classNames = require('classnames');
-import { Callout as FabricCallout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
+import Callout, { DirectionalHint } from '../Callout';
 import { NestableBaseComponentProps } from '../../util/BaseComponent/props';
 import { Key } from '../../util/enums';
 import ScreenreaderText from '../ScreenreaderText';
@@ -90,7 +90,7 @@ export default class Hovercard extends React.Component<HovercardProps, Hovercard
     triggerType: TriggerType.HOVER,
   };
 
-  private triggerElement: HTMLSpanElement;
+  private triggerElement: HTMLSpanElement | null;
   private showTimeout: number;
   private hideTimeout: number;
 
@@ -118,7 +118,7 @@ export default class Hovercard extends React.Component<HovercardProps, Hovercard
       </ScreenreaderText>
     );
     const hovercard = this.state.visible && (
-      <FabricCallout
+      <Callout
         isBeakVisible={isBeakVisible}
         directionalHint={directionalHint}
         target={this.triggerElement}
@@ -133,14 +133,14 @@ export default class Hovercard extends React.Component<HovercardProps, Hovercard
           {screenreaderTitleChild}
           {content}
         </div>
-      </FabricCallout>
+      </Callout>
     );
 
     return (
       <span className={classNames('y-hovercard', className)}>
         <span
           className="y-hovercard--trigger"
-          ref={(node: HTMLSpanElement) => (this.triggerElement = node)}
+          ref={node => (this.triggerElement = node)}
           onClick={this.handleTriggerClick}
           onMouseEnter={this.handleTriggerHover}
           onMouseLeave={this.handleTriggerHoverLeave}


### PR DESCRIPTION
Couldn't find any reason to limit Fabric Callout's API as this is pretty much a utility component within YamUI, so I just exposed the Fabric component directly. There's still a little value in this wrapper since the CSS override is managed at this entrypoint instead of in Hovercard.

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [x] Component is unit tested.
