### PR TITLE
[cleanup] Use snapshots to test rendered output

### DIFF
--- a/config/yo/generator-component/app/templates/Component.test.tsx
+++ b/config/yo/generator-component/app/templates/Component.test.tsx
@@ -11,10 +11,6 @@ describe('<<%= name %> />', () => {
       component = shallow(<<%= name %> />);
     });
 
-    it('has its correct base class', () => {
-      expect(component.hasClass('<%= className %>')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -25,14 +21,6 @@ describe('<<%= name %> />', () => {
       component = shallow(
         <<%= name %> className="TEST_CLASSNAME" />,
       );
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('<%= className %>')).toBe(true);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -1,8 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
-import { Persona, PersonaSize } from 'office-ui-fabric-react/lib/Persona';
-import ScreenreaderText from '../ScreenreaderText';
 import Text from '../Text';
 import Avatar, { AvatarProps, AvatarSize, AvatarBorderType } from '.';
 
@@ -14,23 +12,6 @@ describe('<Avatar />', () => {
       component = shallow(<Avatar name="NAME" imageUrl="test.jpg" />);
     });
 
-    it('contains its base className', () => {
-      expect(component.hasClass('y-avatar')).toBe(true);
-    });
-
-    it('renders the given image', () => {
-      expect(
-        component
-          .render()
-          .find('img')
-          .attr('src'),
-      ).toEqual('test.jpg');
-    });
-
-    it('defaults to medium size', () => {
-      expect(component.find(Persona).prop('size')).toEqual(PersonaSize.size40);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -39,15 +20,6 @@ describe('<Avatar />', () => {
   describe('with too many characters', () => {
     beforeEach(() => {
       component = shallow(<Avatar name="First Last" />);
-    });
-
-    it('only renders 2 letters', () => {
-      expect(
-        component
-          .find(Persona)
-          .render()
-          .text(),
-      ).toEqual('FL');
     });
 
     it('matches its snapshot', () => {
@@ -67,16 +39,6 @@ describe('<Avatar />', () => {
       );
     });
 
-    it('renders the given badge content', () => {
-      expect(component.find('.y-avatar--badge').find(Text).length).toEqual(1);
-    });
-
-    it('renders the size class on the badge', () => {
-      expect(component.find('.y-avatar--badge').hasClass('y-avatar__size-xSmall--badge')).toBe(
-        true,
-      );
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -89,10 +51,6 @@ describe('<Avatar />', () => {
       );
     });
 
-    it('contains the soft border class', () => {
-      expect(component.hasClass('y-avatar__borderType-soft')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -103,14 +61,6 @@ describe('<Avatar />', () => {
       component = shallow(<Avatar name="NAME" imageUrl="test.jpg" size={AvatarSize.XLARGE} />);
     });
 
-    it('contains the correct size class', () => {
-      expect(component.hasClass('y-avatar__size-xLarge')).toBe(true);
-    });
-
-    it('renders a Persona component with the correct size', () => {
-      expect(component.find(Persona).prop('size')).toEqual(PersonaSize.size72);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -119,14 +69,6 @@ describe('<Avatar />', () => {
   describe('with additional className', () => {
     beforeEach(() => {
       component = shallow(<Avatar name="NAME" imageUrl="test.jpg" className="TEST_CLASSNAME" />);
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still has its base className', () => {
-      expect(component.hasClass('y-avatar')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -140,14 +82,6 @@ describe('<Avatar />', () => {
         component = shallow(<Avatar name="NAME" imageUrl="test.jpg" />);
       });
 
-      it('renders the name in a ScreenreaderText component', () => {
-        expect(
-          component
-            .find(ScreenreaderText)
-            .matchesElement(<ScreenreaderText>NAME</ScreenreaderText>),
-        ).toEqual(true);
-      });
-
       it('matches its snapshot', () => {
         expect(component).toMatchSnapshot();
       });
@@ -156,14 +90,6 @@ describe('<Avatar />', () => {
     describe('with badge description', () => {
       beforeEach(() => {
         component = shallow(<Avatar name="NAME" imageUrl="test.jpg" badgeDescription="BADGE" />);
-      });
-
-      it('renders the name and badge description in a ScreenreaderText component', () => {
-        expect(
-          component
-            .find(ScreenreaderText)
-            .matchesElement(<ScreenreaderText>NAME - BADGE</ScreenreaderText>),
-        ).toEqual(true);
       });
 
       it('matches its snapshot', () => {

--- a/src/components/Block/Block.test.tsx
+++ b/src/components/Block/Block.test.tsx
@@ -11,14 +11,6 @@ describe('<Block />', () => {
       component = shallow(<Block>block content</Block>);
     });
 
-    it('renders its given content', () => {
-      expect(component.text()).toEqual('block content');
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-block')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -27,14 +19,6 @@ describe('<Block />', () => {
   describe('with additional className', () => {
     beforeEach(() => {
       component = shallow(<Block className="TEST_CLASSNAME">block content</Block>);
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still has its base className', () => {
-      expect(component.hasClass('y-block')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -47,14 +31,6 @@ describe('<Block />', () => {
       component = shallow(<Block textSize={TextSize.XLARGE}>block content</Block>);
     });
 
-    it('includes the xLarge className', () => {
-      expect(component.hasClass('y-textSize-xLarge')).toBe(true);
-    });
-
-    it('still has its base className', () => {
-      expect(component.hasClass('y-block')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -64,14 +40,6 @@ describe('<Block />', () => {
     describe('right', () => {
       beforeEach(() => {
         component = shallow(<Block textAlign="right">block content</Block>);
-      });
-
-      it('includes the aligned right className', () => {
-        expect(component.hasClass('y-block__textAlign-right')).toBe(true);
-      });
-
-      it('still has its base className', () => {
-        expect(component.hasClass('y-block')).toBe(true);
       });
 
       it('matches its snapshot', () => {
@@ -105,10 +73,6 @@ describe('<Block />', () => {
       component = shallow(<Block bottomSpacing={GutterSize.XLARGE}>block content</Block>);
     });
 
-    it('contains the bottomSpacing className', () => {
-      expect(component.hasClass('y-block__bottomSpacing-xLarge')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -117,10 +81,6 @@ describe('<Block />', () => {
   describe('with padding', () => {
     beforeEach(() => {
       component = shallow(<Block padding={GutterSize.SMALL}>block content</Block>);
-    });
-
-    it('contains the padding className', () => {
-      expect(component.find('.y-block--inner__padding-small').length).toEqual(1);
     });
 
     it('matches its snapshot', () => {
@@ -133,10 +93,6 @@ describe('<Block />', () => {
       component = shallow(<Block push={3}>block content</Block>);
     });
 
-    it('adds top outer padding', () => {
-      expect(component.first().getNode().props.style.paddingTop).toEqual('0.3rem');
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -145,10 +101,6 @@ describe('<Block />', () => {
   describe('with negative push', () => {
     beforeEach(() => {
       component = shallow(<Block push={-2}>block content</Block>);
-    });
-
-    it('adds a negative top margin', () => {
-      expect(component.first().getNode().props.style.marginTop).toEqual('-0.2rem');
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,7 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
-import { BaseButton } from 'office-ui-fabric-react/lib/Button';
 import Button, { ButtonProps, ButtonColor, ButtonStatus, ButtonIconPosition, ButtonSize } from '.';
 import { Accounts as AccountsIcon } from '../Icon';
 
@@ -16,22 +15,6 @@ describe('<Button />', () => {
       component = shallow(<Button text={sampleText} />);
     });
 
-    it('renders a Fabric BaseButton', () => {
-      expect(component.find(BaseButton).length).toBe(1);
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-button')).toBe(true);
-    });
-
-    it('is the default button size', () => {
-      expect(component.hasClass('y-button__size-regular')).toBe(true);
-    });
-
-    it('is the default button color', () => {
-      expect(component.hasClass('y-button__color-secondary')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -40,14 +23,6 @@ describe('<Button />', () => {
   describe('with additional className', () => {
     beforeEach(() => {
       component = shallow(<Button text={sampleText} className="TEST_CLASSNAME" />);
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still has its base className', () => {
-      expect(component.hasClass('y-button')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -60,10 +35,6 @@ describe('<Button />', () => {
       component = shallow(<Button text={sampleText} ariaLabel={sampleAriaLabel} />);
     });
 
-    it('prop is set', () => {
-      expect(component.find(BaseButton).prop('ariaLabel')).toEqual(sampleAriaLabel);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -72,10 +43,6 @@ describe('<Button />', () => {
   describe('with fullWidth', () => {
     beforeEach(() => {
       component = shallow(<Button text={sampleText} fullWidth={true} />);
-    });
-
-    it('includes the fullWidth className', () => {
-      expect(component.hasClass('y-button__fullWidth')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -88,10 +55,6 @@ describe('<Button />', () => {
       component = shallow(<Button text={sampleText} status={ButtonStatus.DISABLED} />);
     });
 
-    it('is disabled', () => {
-      expect(component.find(BaseButton).prop('disabled')).toEqual(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -102,10 +65,6 @@ describe('<Button />', () => {
       component = shallow(<Button text={sampleText} status={ButtonStatus.LOADING} />);
     });
 
-    it('is disabled', () => {
-      expect(component.find(BaseButton).prop('disabled')).toEqual(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -114,14 +73,6 @@ describe('<Button />', () => {
   describe('with icon', () => {
     beforeEach(() => {
       component = shallow(<Button icon={AccountsIcon} text={sampleText} />);
-    });
-
-    it('renders the icon on the left', () => {
-      expect(component.find('.y-button--icon-wrapper-left').length).toBe(1);
-    });
-
-    it('renders the actual Icon', () => {
-      expect(component.find(AccountsIcon).length).toBe(1);
     });
 
     it('matches its snapshot', () => {
@@ -139,10 +90,6 @@ describe('<Button />', () => {
         );
       });
 
-      it('renders the icon on the right', () => {
-        expect(component.find('.y-button--icon-wrapper-right').length).toBe(1);
-      });
-
       it('matches its snapshot', () => {
         expect(component).toMatchSnapshot();
       });
@@ -152,10 +99,6 @@ describe('<Button />', () => {
   describe('with primary color', () => {
     beforeEach(() => {
       component = shallow(<Button color={ButtonColor.PRIMARY} text={sampleText} />);
-    });
-
-    it('renders the correct color className', () => {
-      expect(component.hasClass('y-button__color-primary')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -178,14 +121,6 @@ describe('<Button />', () => {
   describe('with small size', () => {
     beforeEach(() => {
       component = shallow(<Button size={ButtonSize.SMALL} text={sampleText} />);
-    });
-
-    it('renders the correct size className', () => {
-      expect(component.hasClass('y-button__size-small')).toBe(true);
-    });
-
-    it('still has its base className', () => {
-      expect(component.hasClass('y-button')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -222,15 +157,6 @@ describe('<Button />', () => {
       component = shallow(<Button text={sampleText} href="https://www.yammer.com" />);
     });
 
-    it('renders a link instead of a button', () => {
-      expect(
-        component
-          .render()
-          .find('a.y-button')
-          .attr('href'),
-      ).toBe('https://www.yammer.com');
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -239,15 +165,6 @@ describe('<Button />', () => {
   describe('with invalid href', () => {
     beforeEach(() => {
       component = shallow(<Button text={sampleText} href="#" />);
-    });
-
-    it('complains via proptypes but does not throw an error', () => {
-      expect(
-        component
-          .render()
-          .find('a.y-button')
-          .attr('href'),
-      ).toBe('#');
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Clickable/Clickable.test.tsx
+++ b/src/components/Clickable/Clickable.test.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import Clickable, { ClickableProps } from '.';
-import FakeLink from '../FakeLink';
 
 describe('<Clickable />', () => {
   let component: ShallowWrapper<ClickableProps, {}>;
@@ -10,14 +9,6 @@ describe('<Clickable />', () => {
   describe('with default options', () => {
     beforeEach(() => {
       component = shallow(<Clickable>clickable content</Clickable>);
-    });
-
-    it('wraps its content in a FakeLink component', () => {
-      expect(component.contains(<FakeLink>clickable content</FakeLink>)).toBe(true);
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-clickable')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -30,14 +21,6 @@ describe('<Clickable />', () => {
       component = shallow(<Clickable className="TEST_CLASSNAME">clickable content</Clickable>);
     });
 
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still has its base className', () => {
-      expect(component.hasClass('y-clickable')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -48,18 +31,6 @@ describe('<Clickable />', () => {
       component = shallow(<Clickable unstyled={true}>clickable content</Clickable>);
     });
 
-    it('renders its given content', () => {
-      expect(component.render().text()).toEqual('clickable content');
-    });
-
-    it('does not wrap its content in a FakeLink component', () => {
-      expect(component.find(FakeLink).length).toBe(0);
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-clickable')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -68,14 +39,6 @@ describe('<Clickable />', () => {
   describe('when block is true', () => {
     beforeEach(() => {
       component = shallow(<Clickable block={true}>clickable content</Clickable>);
-    });
-
-    it('renders the correct block className', () => {
-      expect(component.hasClass('y-clickable__block')).toBe(true);
-    });
-
-    it('still has its base className', () => {
-      expect(component.hasClass('y-clickable')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -90,15 +53,6 @@ describe('<Clickable />', () => {
       );
     });
 
-    it('has title attribute', () => {
-      expect(
-        component
-          .render()
-          .find('button')
-          .attr('title'),
-      ).toEqual('extra browser tooltip content');
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -107,15 +61,6 @@ describe('<Clickable />', () => {
   describe('when ariaLabel is passed', () => {
     beforeEach(() => {
       component = shallow(<Clickable ariaLabel="aria label content">clickable content</Clickable>);
-    });
-
-    it('has aria-label attribute', () => {
-      expect(
-        component
-          .render()
-          .find('button')
-          .attr('aria-label'),
-      ).toEqual('aria label content');
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -10,14 +10,10 @@ import Dropdown, { DropdownProps } from '.';
 describe('<Dropdown />', () => {
   let component: ShallowWrapper<DropdownProps, {}>;
   let fullComponent: ReactWrapper<DropdownProps, {}>;
-  
+
   describe('with default options', () => {
     beforeEach(() => {
       component = shallow(<Dropdown options={[]} />);
-    });
-
-    it('has its correct base class', () => {
-      expect(component.hasClass('y-dropdown')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -28,14 +24,6 @@ describe('<Dropdown />', () => {
   describe('with additional className', () => {
     beforeEach(() => {
       component = shallow(<Dropdown options={[]} className="TEST_CLASSNAME" />);
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-dropdown')).toBe(true);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/FakeLink/FakeLink.test.tsx
+++ b/src/components/FakeLink/FakeLink.test.tsx
@@ -11,14 +11,6 @@ describe('<FakeLink />', () => {
       component = shallow(<FakeLink>link content</FakeLink>);
     });
 
-    it('renders its given content', () => {
-      expect(component.text()).toEqual('link content');
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-fakeLink')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -27,14 +19,6 @@ describe('<FakeLink />', () => {
   describe('with additional className', () => {
     beforeEach(() => {
       component = shallow(<FakeLink className="TEST_CLASSNAME">test content</FakeLink>);
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-fakeLink')).toBe(true);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/FixedGrid/FixedGridColumn.test.tsx
+++ b/src/components/FixedGrid/FixedGridColumn.test.tsx
@@ -11,14 +11,6 @@ describe('<FixedGridColumn />', () => {
       component = shallow(<FixedGridColumn>grid content</FixedGridColumn>);
     });
 
-    it('renders its given content', () => {
-      expect(component.text()).toEqual('grid content');
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-fixedGridColumn')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -31,14 +23,6 @@ describe('<FixedGridColumn />', () => {
       );
     });
 
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-fixedGridColumn')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -47,14 +31,6 @@ describe('<FixedGridColumn />', () => {
   describe('when set to fixed', () => {
     beforeEach(() => {
       component = shallow(<FixedGridColumn fixed={true}>grid content</FixedGridColumn>);
-    });
-
-    it('includes the fixed class name', () => {
-      expect(component.hasClass('y-fixedGridColumn__isFixed')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-fixedGridColumn')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -71,22 +47,6 @@ describe('<FixedGridColumn />', () => {
       );
     });
 
-    it('includes the fixed class name', () => {
-      expect(component.hasClass('y-fixedGridColumn__isFixed')).toBe(true);
-    });
-
-    it('includes the hasWidth class name', () => {
-      expect(component.hasClass('y-fixedGridColumn__hasWidth')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-fixedGridColumn')).toBe(true);
-    });
-
-    it('has a width set in pixels', () => {
-      expect(component.first().getNode().props.style.width).toEqual('150px');
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -97,18 +57,6 @@ describe('<FixedGridColumn />', () => {
       component = shallow(<FixedGridColumn width={150}>grid content</FixedGridColumn>);
     });
 
-    it('does not include the fixed class name', () => {
-      expect(component.hasClass('y-fixedGridColumn__isFixed')).not.toBe(true);
-    });
-
-    it('includes the hasWidth class name', () => {
-      expect(component.hasClass('y-fixedGridColumn__hasWidth')).toBe(true);
-    });
-
-    it('does not have a width set', () => {
-      expect(component.first().getNode().props.style).toEqual({});
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -117,10 +65,6 @@ describe('<FixedGridColumn />', () => {
   describe('with vertical align middle', () => {
     beforeEach(() => {
       component = shallow(<FixedGridColumn verticalAlign="middle">grid content</FixedGridColumn>);
-    });
-
-    it('has the vertical align inner div', () => {
-      expect(component.find('.y-fixedGridColumn--inner__middle').length).toBe(1);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/FixedGrid/FixedGridRow.test.tsx
+++ b/src/components/FixedGrid/FixedGridRow.test.tsx
@@ -11,18 +11,6 @@ describe('<FixedGridRow />', () => {
       component = shallow(<FixedGridRow>grid content</FixedGridRow>);
     });
 
-    it('renders its given content', () => {
-      expect(component.text()).toEqual('grid content');
-    });
-
-    it('defaults to SMALL gutter size (8px)', () => {
-      expect(component.hasClass('y-fixedGridRow__gutter-small')).toBe(true);
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-fixedGridRow')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -31,14 +19,6 @@ describe('<FixedGridRow />', () => {
   describe('with additional className', () => {
     beforeEach(() => {
       component = shallow(<FixedGridRow className="TEST_CLASSNAME">grid content</FixedGridRow>);
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-fixedGridRow')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -51,14 +31,6 @@ describe('<FixedGridRow />', () => {
       component = shallow(<FixedGridRow gutterSize={GutterSize.LARGE}>grid content</FixedGridRow>);
     });
 
-    it('includes the gutter size class name', () => {
-      expect(component.hasClass('y-fixedGridRow__gutter-large')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-fixedGridRow')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -69,14 +41,6 @@ describe('<FixedGridRow />', () => {
       component = shallow(
         <FixedGridRow bottomSpacing={GutterSize.XLARGE}>grid content</FixedGridRow>,
       );
-    });
-
-    it('includes the gutter size class name', () => {
-      expect(component.hasClass('y-fixedGridRow__bottomSpacing-xLarge')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-fixedGridRow')).toBe(true);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -7,21 +7,9 @@ import Heading, { HeadingProps } from '.';
 describe('<Heading />', () => {
   let component: ShallowWrapper<HeadingProps, {}>;
 
-  describe('with a level', () => {
+  describe('with level 1', () => {
     beforeEach(() => {
       component = shallow(<Heading level="1">test content</Heading>);
-    });
-
-    it('renders its given content', () => {
-      expect(component.render().text()).toEqual('test content');
-    });
-
-    it('renders the correct tag', () => {
-      expect(component.find('h1').length).toBe(1);
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-heading')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -29,21 +17,9 @@ describe('<Heading />', () => {
     });
   });
 
-  describe('with a size', () => {
+  describe('with level 2 and size 3', () => {
     beforeEach(() => {
       component = shallow(<Heading level="2" size="3">test content</Heading>);
-    });
-
-    it('renders the correct tag level', () => {
-      expect(component.find('h2').length).toBe(1);
-    });
-
-    it('renders the correct size className', () => {
-      expect(component.hasClass('y-heading__size-3')).toBe(true);
-    });
-
-    it('has its base className', () => {
-      expect(component.hasClass('y-heading')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -56,14 +32,6 @@ describe('<Heading />', () => {
       component = shallow(<Heading level="5" size="none">test content</Heading>);
     });
 
-    it('renders the correct tag level', () => {
-      expect(component.find('h5').length).toBe(1);
-    });
-
-    it('renders the size "none" className', () => {
-      expect(component.hasClass('y-heading__size-none')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -72,14 +40,6 @@ describe('<Heading />', () => {
   describe('with additional className', () => {
     beforeEach(() => {
       component = shallow(<Heading level="4" className="TEST_CLASSNAME">test content</Heading>);
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-heading')).toBe(true);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/Heading/__snapshots__/Heading.test.tsx.snap
@@ -1,6 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Heading /> with a level matches its snapshot 1`] = `
+exports[`<Heading /> with additional className matches its snapshot 1`] = `
+<h4
+  className="y-heading TEST_CLASSNAME"
+>
+  <Block
+    bottomSpacing="medium"
+    textSize="large"
+  >
+    test content
+  </Block>
+</h4>
+`;
+
+exports[`<Heading /> with level 1 matches its snapshot 1`] = `
 <h1
   className="y-heading"
 >
@@ -13,7 +26,7 @@ exports[`<Heading /> with a level matches its snapshot 1`] = `
 </h1>
 `;
 
-exports[`<Heading /> with a size matches its snapshot 1`] = `
+exports[`<Heading /> with level 2 and size 3 matches its snapshot 1`] = `
 <h2
   className="y-heading y-heading__size-3"
 >
@@ -24,19 +37,6 @@ exports[`<Heading /> with a size matches its snapshot 1`] = `
     test content
   </Block>
 </h2>
-`;
-
-exports[`<Heading /> with additional className matches its snapshot 1`] = `
-<h4
-  className="y-heading TEST_CLASSNAME"
->
-  <Block
-    bottomSpacing="medium"
-    textSize="large"
-  >
-    test content
-  </Block>
-</h4>
 `;
 
 exports[`<Heading /> with size "none" matches its snapshot 1`] = `

--- a/src/components/HorizontalList/HorizontalList.test.tsx
+++ b/src/components/HorizontalList/HorizontalList.test.tsx
@@ -11,14 +11,6 @@ describe('<HorizontalList />', () => {
       component = shallow(<HorizontalList />);
     });
 
-    it('renders a ul tag', () => {
-      expect(component.find('ul').length).toBe(1);
-    });
-
-    it('renders its base className', () => {
-      expect(component.hasClass('y-horizontalList')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -27,10 +19,6 @@ describe('<HorizontalList />', () => {
   describe('with align "right"', () => {
     beforeEach(() => {
       component = shallow(<HorizontalList align="right" />);
-    });
-
-    it('adds the align-right class', () => {
-      expect(component.hasClass('y-horizontalList__align-right')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -43,14 +31,6 @@ describe('<HorizontalList />', () => {
       component = shallow(<HorizontalList className="TEST_CLASSNAME" />);
     });
 
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-horizontalList')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -59,10 +39,6 @@ describe('<HorizontalList />', () => {
   describe('with child content', () => {
     beforeEach(() => {
       component = shallow(<HorizontalList>list content</HorizontalList>);
-    });
-
-    it('renders the child content', () => {
-      expect(component.text()).toBe('list content');
     });
 
     it('matches its snapshot', () => {

--- a/src/components/HorizontalList/HorizontalListItem.test.tsx
+++ b/src/components/HorizontalList/HorizontalListItem.test.tsx
@@ -11,14 +11,6 @@ describe('<HorizontalListItem />', () => {
       component = shallow(<HorizontalListItem />);
     });
 
-    it('renders an li element', () => {
-      expect(component.find('li').length).toBe(1);
-    });
-
-    it('renders its base className', () => {
-      expect(component.hasClass('y-horizontalList--item')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -29,14 +21,6 @@ describe('<HorizontalListItem />', () => {
       component = shallow(<HorizontalListItem className="TEST_CLASSNAME" />);
     });
 
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-horizontalList--item')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -45,10 +29,6 @@ describe('<HorizontalListItem />', () => {
   describe('with child content', () => {
     beforeEach(() => {
       component = shallow(<HorizontalListItem>list item content</HorizontalListItem>);
-    });
-
-    it('renders the child content', () => {
-      expect(component.text()).toBe('list item content');
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Hovercard/Hovercard.test.tsx
+++ b/src/components/Hovercard/Hovercard.test.tsx
@@ -20,22 +20,8 @@ describe('<Hovercard />', () => {
       );
     });
 
-    describe('at initial render', () => {
-      it('renders its trigger content', () => {
-        expect(component.find('.y-hovercard--trigger').text()).toEqual('Trigger');
-      });
-
-      it('contains its base className', () => {
-        expect(component.hasClass('y-hovercard')).toBe(true);
-      });
-
-      it('does not show the hovercard', () => {
-        expect(component.find(Callout).length).toBe(0);
-      });
-
-      it('matches its snapshot', () => {
-        expect(component).toMatchSnapshot();
-      });
+    it('matches its snapshot', () => {
+      expect(component).toMatchSnapshot();
     });
   });
 
@@ -46,14 +32,6 @@ describe('<Hovercard />', () => {
           <span>Trigger</span>
         </Hovercard>,
       );
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still has its base className', () => {
-      expect(component.hasClass('y-hovercard')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -73,12 +51,6 @@ describe('<Hovercard />', () => {
         </Hovercard>,
       );
       component.find('.y-hovercard--trigger').simulate('click');
-    });
-
-    it('renders the hidden title', () => {
-      expect(component.find('.y-hovercard--modal-container ScreenreaderText h1').text()).toEqual(
-        'HIDDEN TITLE',
-      );
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Hovercard/__snapshots__/Hovercard.test.tsx.snap
+++ b/src/components/Hovercard/__snapshots__/Hovercard.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<Hovercard /> with additional className matches its snapshot 1`] = `
 </span>
 `;
 
-exports[`<Hovercard /> with default options at initial render matches its snapshot 1`] = `
+exports[`<Hovercard /> with default options matches its snapshot 1`] = `
 <span
   className="y-hovercard"
 >

--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -8,14 +8,10 @@ describe('<Icon />', () => {
   let component: ShallowWrapper<IconProps, {}>;
 
   describe('an Icon', () => {
-      
+
     describe('with minimal options', () => {
       beforeEach(() => {
         component = shallow(<Accounts />);
-      });
-
-      it('contains its base className', () => {
-        expect(component.hasClass('y-icon')).toBe(true);
       });
 
       it('matches its snapshot', () => {
@@ -28,9 +24,6 @@ describe('<Icon />', () => {
         component = shallow(<Accounts color="blue" />);
       });
 
-      it('contains the given color style', () => {
-        expect(component.getNode().props.style.color).toEqual('blue');
-      });
 
       it('matches its snapshot', () => {
         expect(component).toMatchSnapshot();
@@ -40,10 +33,6 @@ describe('<Icon />', () => {
     describe('with block', () => {
       beforeEach(() => {
         component = shallow(<Accounts block={true} />);
-      });
-
-      it('contains its block className', () => {
-        expect(component.hasClass('y-icon__isBlock')).toBe(true);
       });
 
       it('matches its snapshot', () => {
@@ -56,14 +45,6 @@ describe('<Icon />', () => {
         component = shallow(<Accounts size={IconSize.XXLARGE} />);
       });
 
-      it('is the correct height', () => {
-        expect(component.getNode().props.style.height).toBe(IconSize.XXLARGE + 'px');
-      });
-
-      it('is the correct width', () => {
-        expect(component.getNode().props.style.width).toBe(IconSize.XXLARGE + 'px');
-      });
-
       it('matches its snapshot', () => {
         expect(component).toMatchSnapshot();
       });
@@ -72,14 +53,6 @@ describe('<Icon />', () => {
     describe('with additional className', () => {
       beforeEach(() => {
         component = shallow(<Accounts className="TEST_CLASSNAME" />);
-      });
-
-      it('includes that className', () => {
-        expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-      });
-
-      it('still includes its base className', () => {
-        expect(component.hasClass('y-icon')).toBe(true);
       });
 
       it('matches its snapshot', () => {

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -1,7 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
 import { mount, ReactWrapper, shallow, ShallowWrapper } from 'enzyme';
-import { Image as FabricImage } from 'office-ui-fabric-react/lib/Image';
 import Image, { ImageProps, ImageFit, ImageLoadState } from '.';
 
 describe('<Image />', () => {
@@ -11,34 +10,6 @@ describe('<Image />', () => {
   describe('with default options', () => {
     beforeEach(() => {
       component = shallow(<Image source="image.png" description="description" />);
-    });
-
-    it('has its correct base class', () => {
-      expect(component.hasClass('y-image')).toBe(true);
-    });
-
-    it('uses the source as img src', () => {
-      expect(component.find(FabricImage).props().src).toEqual('image.png');
-    });
-
-    it('uses the description as img alt text', () => {
-      expect(component.find(FabricImage).props().alt).toEqual('description');
-    });
-
-    it('does not set a height', () => {
-      expect(component.find(FabricImage).props().height).toEqual(undefined);
-    });
-
-    it('does not set a width', () => {
-      expect(component.find(FabricImage).props().width).toEqual(undefined);
-    });
-
-    it('does not set an imageFit', () => {
-      expect(component.find(FabricImage).props().imageFit).toEqual(undefined);
-    });
-
-    it('does not fade in', () => {
-      expect(component.find(FabricImage).props().shouldFadeIn).toEqual(false);
     });
 
     it('matches its snapshot', () => {
@@ -53,44 +24,28 @@ describe('<Image />', () => {
       );
     });
 
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
   });
 
-  describe('with height and width', () => {
+  describe('with height 50 and width 100', () => {
     beforeEach(() => {
       component = shallow(
         <Image source="image.png" description="description" height={50} width={100} />,
       );
     });
 
-    it('uses the given height', () => {
-      expect(component.find(FabricImage).props().height).toEqual(50);
-    });
-
-    it('uses the given width', () => {
-      expect(component.find(FabricImage).props().width).toEqual(100);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
   });
 
-  describe('with imageFit', () => {
+  describe('with imageFit cover', () => {
     beforeEach(() => {
       component = shallow(
         <Image source="image.png" description="description" imageFit={ImageFit.cover} />,
       );
-    });
-
-    it('uses the given imageFit', () => {
-      expect(component.find(FabricImage).props().imageFit).toEqual(ImageFit.cover);
     });
 
     it('matches its snapshot', () => {
@@ -103,18 +58,6 @@ describe('<Image />', () => {
       component = shallow(<Image source="image.png" description="description" fullWidth={true} />);
     });
 
-    it('renders the fullWidth class', () => {
-      expect(component.hasClass('y-image__fullWidth')).toBe(true);
-    });
-
-    it('uses width 100%', () => {
-      expect(component.find(FabricImage).props().width).toEqual('100%');
-    });
-
-    it('does not pass an image height', () => {
-      expect(component.find(FabricImage).props().height).toEqual(undefined);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -125,10 +68,6 @@ describe('<Image />', () => {
       component = shallow(
         <Image source="image.png" description="description" shouldFadeIn={true} />,
       );
-    });
-
-    it('tells the Fabric Image to fade in', () => {
-      expect(component.find(FabricImage).props().shouldFadeIn).toEqual(true);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Image/__snapshots__/Image.test.tsx.snap
+++ b/src/components/Image/__snapshots__/Image.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<Image /> with fullWidth matches its snapshot 1`] = `
 />
 `;
 
-exports[`<Image /> with height and width matches its snapshot 1`] = `
+exports[`<Image /> with height 50 and width 100 matches its snapshot 1`] = `
 <Image
   alt="description"
   className="y-image"
@@ -39,7 +39,7 @@ exports[`<Image /> with height and width matches its snapshot 1`] = `
 />
 `;
 
-exports[`<Image /> with imageFit matches its snapshot 1`] = `
+exports[`<Image /> with imageFit cover matches its snapshot 1`] = `
 <Image
   alt="description"
   className="y-image"

--- a/src/components/MediaObject/MediaObject.test.tsx
+++ b/src/components/MediaObject/MediaObject.test.tsx
@@ -17,18 +17,6 @@ describe('<MediaObject />', () => {
       component = shallow(<MediaObject size={MediaObjectSize.MEDIUM} />);
     });
 
-    it('contains its base className', () => {
-      expect(component.hasClass('y-media-object')).toBe(true);
-    });
-
-    it('contains its size className', () => {
-      expect(component.hasClass('y-media-object__size-medium')).toBe(true);
-    });
-
-    it('image column contains its size className', () => {
-      expect(component.find('.y-media-object__size-medium--image').length).toBe(1);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -39,14 +27,6 @@ describe('<MediaObject />', () => {
       component = shallow(<MediaObject size={MediaObjectSize.MEDIUM} className="TEST_CLASSNAME" />);
     });
 
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still has its base className', () => {
-      expect(component.hasClass('y-media-object')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -55,15 +35,7 @@ describe('<MediaObject />', () => {
   describe('with image content', () => {
     beforeEach(() => {
       component = shallow(<MediaObject size={MediaObjectSize.MEDIUM} imageContent={image} />);
-    });
-
-    it('renders the image content', () => {
-      expect(
-        component
-          .render()
-          .find('img')
-          .attr('src'),
-      ).toEqual('404.jpg');
+      component.render();
     });
 
     it('matches its snapshot', () => {
@@ -74,15 +46,7 @@ describe('<MediaObject />', () => {
   describe('with title content', () => {
     beforeEach(() => {
       component = shallow(<MediaObject size={MediaObjectSize.MEDIUM} titleContent={title} />);
-    });
-
-    it('renders the title content', () => {
-      expect(
-        component
-          .render()
-          .find('.TITLE')
-          .text(),
-      ).toEqual('TITLE CONTENT');
+      component.render();
     });
 
     it('matches its snapshot', () => {
@@ -93,15 +57,7 @@ describe('<MediaObject />', () => {
   describe('with metadata content', () => {
     beforeEach(() => {
       component = shallow(<MediaObject size={MediaObjectSize.MEDIUM} metadataContent={metadata} />);
-    });
-
-    it('renders the metadata content', () => {
-      expect(
-        component
-          .render()
-          .find('.METADATA')
-          .text(),
-      ).toEqual('METADATA CONTENT');
+      component.render();
     });
 
     it('matches its snapshot', () => {
@@ -115,10 +71,6 @@ describe('<MediaObject />', () => {
         );
       });
 
-      it('does not render the metadata content', () => {
-        expect(component.render().find('.METADATA').length).toEqual(0);
-      });
-
       it('matches its snapshot', () => {
         expect(component).toMatchSnapshot();
       });
@@ -130,10 +82,6 @@ describe('<MediaObject />', () => {
       component = shallow(<MediaObject size={MediaObjectSize.MEDIUM} extraContent={extra} />);
     });
 
-    it('does not render the extra content by default', () => {
-      expect(component.render().find('.EXTRA').length).toEqual(0);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -141,15 +89,7 @@ describe('<MediaObject />', () => {
     describe('at extra large size', () => {
       beforeEach(() => {
         component = shallow(<MediaObject size={MediaObjectSize.XLARGE} extraContent={extra} />);
-      });
-
-      it('does render the extra content', () => {
-        expect(
-          component
-            .render()
-            .find('.EXTRA')
-            .text(),
-        ).toEqual('EXTRA CONTENT');
+        component.render();
       });
 
       it('matches its snapshot', () => {
@@ -161,15 +101,7 @@ describe('<MediaObject />', () => {
   describe('with arbitrary children', () => {
     beforeEach(() => {
       component = shallow(<MediaObject size={MediaObjectSize.MEDIUM}>{children}</MediaObject>);
-    });
-
-    it('renders them', () => {
-      expect(
-        component
-          .render()
-          .find('.CHILDREN')
-          .text(),
-      ).toEqual('CHILDREN CONTENT');
+      component.render();
     });
 
     it('matches its snapshot', () => {

--- a/src/components/MessageBar/MessageBar.test.tsx
+++ b/src/components/MessageBar/MessageBar.test.tsx
@@ -12,10 +12,6 @@ describe('<MessageBar />', () => {
       component = shallow(<MessageBar>content</MessageBar>);
     });
 
-    it('has its correct base class', () => {
-      expect(component.hasClass('y-message-bar')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -28,14 +24,6 @@ describe('<MessageBar />', () => {
           content
         </MessageBar>,
       );
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-message-bar')).toBe(true);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/NavigationLink/NavigationLink.test.tsx
+++ b/src/components/NavigationLink/NavigationLink.test.tsx
@@ -11,18 +11,6 @@ describe('<NavigationLink />', () => {
       component = shallow(<NavigationLink href="test.html">link content</NavigationLink>);
     });
 
-    it('renders its given content', () => {
-      expect(component.text()).toBe('link content');
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-navigationLink')).toBe(true);
-    });
-
-    it('uses the given href', () => {
-      expect(component.getNode().props.href).toBe('test.html');
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -35,14 +23,6 @@ describe('<NavigationLink />', () => {
           link content
         </NavigationLink>,
       );
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-navigationLink')).toBe(true);
-    });
-
-    it('contains its unstyled className', () => {
-      expect(component.hasClass('y-navigationLink__unstyled')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -59,10 +39,6 @@ describe('<NavigationLink />', () => {
       );
     });
 
-    it('contains the given title', () => {
-      expect(component.getNode().props.title).toBe('TITLE CONTENT');
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -77,10 +53,6 @@ describe('<NavigationLink />', () => {
       );
     });
 
-    it('contains the correct rel attribute', () => {
-      expect(component.getNode().props.rel).toBe('nofollow noreferrer');
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -93,14 +65,6 @@ describe('<NavigationLink />', () => {
           test content
         </NavigationLink>,
       );
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBeTruthy();
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-navigationLink')).toBeTruthy();
     });
 
     it('matches its snapshot', () => {

--- a/src/components/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.test.tsx
@@ -13,10 +13,6 @@ describe('<ProgressIndicator />', () => {
       );
     });
 
-    it('includes the incomplete classname (for square progress bar corners)', () => {
-      expect(component.hasClass('y-progress-indicator__incomplete')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -27,10 +23,6 @@ describe('<ProgressIndicator />', () => {
       component = shallow(
         <ProgressIndicator ariaValueText="100% complete" percentComplete={1} />,
       );
-    });
-
-    it('does not include the incomplete classname', () => {
-      expect(component.hasClass('y-progress-indicator__incomplete')).toBe(false);
     });
 
     it('matches its snapshot', () => {
@@ -47,14 +39,6 @@ describe('<ProgressIndicator />', () => {
           className="TEST_CLASS"
         />,
       );
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASS')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-progress-indicator')).toBe(true);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/ScreenreaderText/ScreenreaderText.test.tsx
+++ b/src/components/ScreenreaderText/ScreenreaderText.test.tsx
@@ -11,14 +11,6 @@ describe('<ScreenreaderText />', () => {
       component = shallow(<ScreenreaderText>text content</ScreenreaderText>);
     });
 
-    it('renders its given content', () => {
-      expect(component.text()).toEqual('text content');
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-screenreaderText')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -29,14 +21,6 @@ describe('<ScreenreaderText />', () => {
       component = shallow(
         <ScreenreaderText className="TEST_CLASSNAME">test content</ScreenreaderText>,
       );
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-screenreaderText')).toBe(true);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Spinner/Spinner.test.tsx
+++ b/src/components/Spinner/Spinner.test.tsx
@@ -13,14 +13,6 @@ describe('<Spinner />', () => {
       );
     });
 
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-spinner')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -12,14 +12,6 @@ describe('<Text />', () => {
       component = shallow(<Text>test content</Text>);
     });
 
-    it('renders its given content', () => {
-      expect(component.text()).toEqual('test content');
-    });
-
-    it('contains its base className', () => {
-      expect(component.hasClass('y-text')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -28,14 +20,6 @@ describe('<Text />', () => {
   describe('with additional className', () => {
     beforeEach(() => {
       component = shallow(<Text className="TEST_CLASSNAME">test content</Text>);
-    });
-
-    it('includes that className', () => {
-      expect(component.hasClass('TEST_CLASSNAME')).toBe(true);
-    });
-
-    it('still includes its base className', () => {
-      expect(component.hasClass('y-text')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -48,14 +32,6 @@ describe('<Text />', () => {
       component = shallow(<Text size={TextSize.XLARGE}>test content</Text>);
     });
 
-    it('renders the correct size className', () => {
-      expect(component.hasClass('y-textSize-xLarge')).toBe(true);
-    });
-
-    it('still has its base className', () => {
-      expect(component.hasClass('y-text')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -66,10 +42,6 @@ describe('<Text />', () => {
       component = shallow(<Text bold={true}>test content</Text>);
     });
 
-    it('renders the bold className', () => {
-      expect(component.hasClass('y-text__bold')).toBe(true);
-    });
-
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
     });
@@ -78,10 +50,6 @@ describe('<Text />', () => {
   describe('with uppercase', () => {
     beforeEach(() => {
       component = shallow(<Text uppercase={true}>test content</Text>);
-    });
-
-    it('renders the uppercase className', () => {
-      expect(component.hasClass('y-text__uppercase')).toBe(true);
     });
 
     it('matches its snapshot', () => {
@@ -99,13 +67,9 @@ describe('<Text />', () => {
     });
   });
 
-  describe('with a valid color', () => {
+  describe('with color secondary', () => {
     beforeEach(() => {
       component = shallow(<Text color={TextColor.SECONDARY}>test content</Text>);
-    });
-
-    it('renders the correct color className', () => {
-      expect(component.hasClass('y-text__color-secondary')).toBe(true);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Text /> with a valid color matches its snapshot 1`] = `
-<span
-  className="y-text y-text__color-secondary"
-  style={Object {}}
->
-  test content
-</span>
-`;
-
 exports[`<Text /> with a valid size matches its snapshot 1`] = `
 <span
   className="y-text y-textSize-xLarge"
@@ -30,6 +21,15 @@ exports[`<Text /> with additional className matches its snapshot 1`] = `
 exports[`<Text /> with bold matches its snapshot 1`] = `
 <span
   className="y-text y-text__bold"
+  style={Object {}}
+>
+  test content
+</span>
+`;
+
+exports[`<Text /> with color secondary matches its snapshot 1`] = `
+<span
+  className="y-text y-text__color-secondary"
   style={Object {}}
 >
   test content


### PR DESCRIPTION
We should just be using snapshots to test the rendered output rather than flooding our files with unnecessary prop checks everywhere

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [x] Component is unit tested.
