### PR TITLE
[avatar] Support disabling fade in

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -44,12 +44,17 @@ export interface AvatarProps extends BaseComponentProps {
    */
   imageUrl?: string;
 
-
   /**
    * XLARGE: 72px, LARGE: 48px, MEDIUM: 40px, SMALL: 32px, XSMALL: 24px.
    * @default AvatarSize.MEDIUM
    */
   size?: AvatarSize;
+
+  /**
+   * Will hide the image until it has loaded, then fade it in.
+   * @default false
+   */
+  imageShouldFadeIn?: boolean;
 }
 
 /**
@@ -62,7 +67,7 @@ export default class Avatar extends React.Component<AvatarProps, {}> {
   };
 
   render() {
-    const { badgeContent, imageUrl, name, size } = this.props;
+    const { badgeContent, imageUrl, name, size, imageShouldFadeIn } = this.props;
     const personaSize = SizeMap[size as string];
 
     const badge = badgeContent && (
@@ -78,6 +83,7 @@ export default class Avatar extends React.Component<AvatarProps, {}> {
           size={personaSize}
           hidePersonaDetails={true}
           primaryText={name}
+          imageShouldFadeIn={imageShouldFadeIn}
         />
         {badge}
         <ScreenreaderText>{this.getAccessibleText()}</ScreenreaderText>


### PR DESCRIPTION
For highly dynamic content e.g. lists, drop-downs etc, Avatar images fading in every render is distracting, this adds a prop to pass through to Persona's imageShouldFadeIn

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [x] Component is unit tested.
