### PR TITLE
Allow tooltip to work in an overflow:hidden parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ It's best to have at least 30GB of free space for Docker containers and images. 
 
 ### Starting up the dev server
 
-* `npm run start:dev` and visit [localhost:5555](http://localhost:5555/)
+* `npm run start` and visit [localhost:5555](http://localhost:5555/)
 
 ### Building some components
 
@@ -69,7 +69,7 @@ It's best to have at least 30GB of free space for Docker containers and images. 
 
 ### Writing unit tests
 
-* `npm run start:test` will start Jest in watch mode, showing passing status and a coverage report. The CLI task remains active and will re-test automatically as you make changes.
+* `npm run watch:jest` will start Jest in watch mode, showing passing status and a coverage report. The CLI task remains active and will re-test automatically as you make changes.
 
 ### Running visual diff regression tests
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,8 @@
     "test:visual:approve": "styleguidist-visual approve --config config/styleguide-visual/config.js",
     "test:visual": "run-s clean:docs test:visual:build test:visual:run",
     "test": "run-s build test:*",
+    "start": "npm run start:dev",
+    "watch:jest": "npm run start:test",
     "start:dev": "styleguidist server --config config/styleguide/config.js",
     "start:test": "jest --config config/jest/config.json --watchAll",
     "svg:generate": "node config/icons/generate",

--- a/src/components/Tooltip/Tooltip.css
+++ b/src/components/Tooltip/Tooltip.css
@@ -9,7 +9,7 @@
   z-index: 1000;
 }
 
-.y-tooltip .ms-Tooltip-content {
+.y-tooltip--callout .ms-Tooltip-content {
   @extend text__small;
   color: $textColor__white;
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -33,7 +33,7 @@ export default class Tooltip extends React.Component<TooltipProps, {}> {
         content={text}
         directionalHint={directionalHint}
         delay={TooltipDelay.medium}
-        calloutProps={{ doNotLayer: true, preventDismissOnScroll: true, beakWidth: 8 }}
+        calloutProps={{ beakWidth: 8 }}
         hostClassName={join(['y-tooltip', className])}
         className="y-tooltip--callout"
       >

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -5,8 +5,6 @@ exports[`<Tooltip /> with additional className matches its snapshot 1`] = `
   calloutProps={
     Object {
       "beakWidth": 8,
-      "doNotLayer": true,
-      "preventDismissOnScroll": true,
     }
   }
   className="y-tooltip--callout"
@@ -21,8 +19,6 @@ exports[`<Tooltip /> with default options matches its snapshot 1`] = `
   calloutProps={
     Object {
       "beakWidth": 8,
-      "doNotLayer": true,
-      "preventDismissOnScroll": true,
     }
   }
   className="y-tooltip--callout"
@@ -39,8 +35,6 @@ exports[`<Tooltip /> with directionalHint matches its snapshot 1`] = `
   calloutProps={
     Object {
       "beakWidth": 8,
-      "doNotLayer": true,
-      "preventDismissOnScroll": true,
     }
   }
   className="y-tooltip--callout"


### PR DESCRIPTION
Enables layering so Tooltip is rendered in a separate Fabric Layer with position:fixed instead of directly in its parent component with position:absolute. The downside is the Tooltip will disappear on scroll (same as Hovercard, and the existing Hovercard & Tooltip implementations on Yammer.com).

Also aliases "npm run start:dev" to "npm run start / npm start" and "npm run start:test" to "npm run jest:watch" to align with our other repos. Eventually we can delete the original "start:dev" and "start:test" aliases.

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [x] Component is unit tested.
