### PR TITLE
Remove NPM warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "version": "4.2.0",
   "style": "dist/yamui-base.css",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/YamUI.git"
+  },
   "dependencies": {
     "core-decorators": "=0.20.0",
     "normalize.css": "=6.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "rimraf": "=2.6.1",
     "style-loader": "=0.16.1",
     "svgo": "=1.0.3",
-    "ts-jest": "=20.0.6",
+    "ts-jest": "=22.0.1",
     "ts-loader": "=3.1.0",
     "tslint": "=5.6.0",
     "tslint-config-airbnb": "=5.2.1",


### PR DESCRIPTION
*Describe the change you are making*

This commit silten NPM warnings:

```sh
npm install
npm WARN ts-jest@20.0.6 requires a peer of jest@^20.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN yamui@4.2.0 No repository field.

up to date in 11.287s
```
to:

```sh
npm install
up to date in 11.198s
```

The PR is split into two separate comits:
- simple `package.json` update by `repository` tag being added
- udpate to `ts-jest` package version to be in sync with `jest` peer dependency 

The `repository` property update is simple and allows to use commands like `npm docs` or `npm repo` to switch to the project home.

The `ts-jest` is pushed as separate commit as it could also require `package-lock.json` update, which is not part of the PR as I have no idea on your policy of updating `package-lock.json`.
The tests have been run after update:

```sh
npm test

> yamui@4.2.0 test /Users/piotrblazejewicz/git/YamUI
> run-s build test:*


> yamui@4.2.0 build /Users/piotrblazejewicz/git/YamUI
> run-s clean build:**


....
 PASS  src/components/Icon/Icon.test.tsx (19.403s)

Test Suites: 34 passed, 34 total
Tests:       341 passed, 341 total
Snapshots:   168 passed, 168 total
Time:        21.064s
Ran all test suites.
```

## Pull request checklist

* [X] Component `README.md` file is up-to-date.
* [x] Component is unit tested.