### PR TITLE
Removed border for tooltips.

### DIFF
--- a/src/components/Tooltip/Tooltip.css
+++ b/src/components/Tooltip/Tooltip.css
@@ -7,6 +7,7 @@
   padding: .7rem 1.2rem .8rem;
   min-height: 3.2rem;
   z-index: 1000;
+  border: none;
 }
 
 .y-tooltip--callout .ms-Tooltip-content {


### PR DESCRIPTION
Force no border for tooltip component.
Fabric is sometimes adding borders for tooltips.

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [x] Component is unit tested.
