### PR TITLE
Use aria-required attribute for Textfield instead of required

### DIFF
--- a/src/components/BaseTextField/BaseTextField.css
+++ b/src/components/BaseTextField/BaseTextField.css
@@ -38,9 +38,3 @@
   color: $textColor__error;
   padding-top: .2rem;
 }
-
-/* Hide the asterisk that comes with required=true */
-.y-base-text-field .ms-Label::after,
-.y-base-text-field .ms-TextField-fieldGroup::after {
-  display: none;
-}

--- a/src/components/BaseTextField/index.ts
+++ b/src/components/BaseTextField/index.ts
@@ -72,7 +72,7 @@ export function getBaseTextFieldProps<T extends BaseTextFieldProps>(props: T): F
     label: props.label,
     description: props.errorMessage ? undefined : props.description,
     disabled: props.disabled,
-    required: props.required,
+    'aria-required': props.required,
     errorMessage: props.errorMessage,
     placeholder: props.placeHolder,
     onFocus: props.onFocus,

--- a/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<TextArea /> with all options matches its snapshot 1`] = `
 <TextField
+  aria-required={true}
   autoAdjustHeight={true}
   borderless={false}
   className="y-base-text-field y-text-area CLASS"
@@ -19,7 +20,6 @@ exports[`<TextArea /> with all options matches its snapshot 1`] = `
   onMouseLeave={[MockFunction onMouseLeave]}
   onNotifyValidationResult={[Function]}
   placeholder="PLACEHOLDER"
-  required={true}
   resizable={false}
   rows={2}
   underlined={false}

--- a/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<TextField /> with all options matches its snapshot 1`] = `
 <TextField
+  aria-required={true}
   autoAdjustHeight={false}
   borderless={false}
   className="y-base-text-field y-text-field CLASS y-text-field--with-prefix y-text-field--with-suffix"
@@ -20,7 +21,6 @@ exports[`<TextField /> with all options matches its snapshot 1`] = `
   onNotifyValidationResult={[Function]}
   placeholder="PLACEHOLDER"
   prefix="PREFIX"
-  required={true}
   resizable={true}
   suffix="SUFFIX"
   underlined={true}


### PR DESCRIPTION
`required` was triggering undesired browser behaviour. `aria-required` will still announce that the field is required without the undesired side effects. 

- added benefit is that I was also able to remove a style override that was hiding the asterisk that came along with `required`

![yammer___screen_shot_2018-02-16_at_3_13_03_pm](https://user-images.githubusercontent.com/601657/36576954-f48ebf62-1808-11e8-87a7-b80a6fe98ff9.png)




