### PR TITLE
Add High Contrast rules for SuggestionsList

### DIFF
--- a/src/components/SuggestionsList/SuggestionsList.tsx
+++ b/src/components/SuggestionsList/SuggestionsList.tsx
@@ -64,7 +64,7 @@ export default class SuggestionsList extends React.PureComponent<SuggestionsList
     const status = this.getSearchStatus();
     const results = this.getGroupedResults();
 
-    const classNames = ['y-suggestions-list'];
+    const classNames = ['y-suggestions-list', 'y-hc-border'];
     if (status) {
       classNames.push(withStatusClass);
     }

--- a/src/components/SuggestionsList/SuggestionsListItem.tsx
+++ b/src/components/SuggestionsList/SuggestionsListItem.tsx
@@ -20,8 +20,8 @@ export interface SuggestionsListItemProps extends SuggestionItem, NestableBaseCo
   onSelect(id: string | number): void;
 }
 
-const baseClass = 'y-suggestions-list-item';
-const selectedClass = `${baseClass} y-suggestions-list-item--selected`;
+const baseClass = 'y-suggestions-list-item y-hc-select-on-hover y-hc-suppress-text-background';
+const selectedClass = `${baseClass} y-suggestions-list-item--selected y-hc-selected`;
 
 const getHighlightedName = (name: string, search: string) => {
   return name.split(new RegExp(`(${search})`, 'gi')).map((item: string, index: number) => {

--- a/src/components/SuggestionsList/__snapshots__/SuggestionsList.test.tsx.snap
+++ b/src/components/SuggestionsList/__snapshots__/SuggestionsList.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<SuggestionsList /> when isLoading=false with results renders as expected 1`] = `
 <div
-  className="y-suggestions-list y-suggestions-list--with-results"
+  className="y-suggestions-list y-hc-border y-suggestions-list--with-results"
 >
   <ul
     className="y-suggestions-list--results"
@@ -30,7 +30,7 @@ exports[`<SuggestionsList /> when isLoading=false with results when onHover is c
 
 exports[`<SuggestionsList /> when isLoading=false with results with state.hoveredId=id renders as expected 1`] = `
 <div
-  className="y-suggestions-list y-suggestions-list--with-results"
+  className="y-suggestions-list y-hc-border y-suggestions-list--with-results"
 >
   <ul
     className="y-suggestions-list--results"
@@ -56,7 +56,7 @@ exports[`<SuggestionsList /> when isLoading=false with results with state.hovere
 
 exports[`<SuggestionsList /> when isLoading=false with results with state.hoveredId=id when the mouse leaves renders as expected 1`] = `
 <div
-  className="y-suggestions-list y-suggestions-list--with-results"
+  className="y-suggestions-list y-hc-border y-suggestions-list--with-results"
 >
   <ul
     className="y-suggestions-list--results"
@@ -82,7 +82,7 @@ exports[`<SuggestionsList /> when isLoading=false with results with state.hovere
 
 exports[`<SuggestionsList /> when isLoading=false without results renders as expected 1`] = `
 <div
-  className="y-suggestions-list y-suggestions-list--with-status"
+  className="y-suggestions-list y-hc-border y-suggestions-list--with-status"
 >
   <Block
     padding="large"
@@ -101,7 +101,7 @@ exports[`<SuggestionsList /> when isLoading=false without results renders as exp
 
 exports[`<SuggestionsList /> when isLoading=true with results renders as expected 1`] = `
 <div
-  className="y-suggestions-list y-suggestions-list--with-status y-suggestions-list--with-results"
+  className="y-suggestions-list y-hc-border y-suggestions-list--with-status y-suggestions-list--with-results"
 >
   <ul
     className="y-suggestions-list--results"
@@ -140,7 +140,7 @@ exports[`<SuggestionsList /> when isLoading=true with results when onHover is ca
 
 exports[`<SuggestionsList /> when isLoading=true with results with state.hoveredId=id renders as expected 1`] = `
 <div
-  className="y-suggestions-list y-suggestions-list--with-status y-suggestions-list--with-results"
+  className="y-suggestions-list y-hc-border y-suggestions-list--with-status y-suggestions-list--with-results"
 >
   <ul
     className="y-suggestions-list--results"
@@ -177,7 +177,7 @@ exports[`<SuggestionsList /> when isLoading=true with results with state.hovered
 
 exports[`<SuggestionsList /> when isLoading=true with results with state.hoveredId=id when the mouse leaves renders as expected 1`] = `
 <div
-  className="y-suggestions-list y-suggestions-list--with-status y-suggestions-list--with-results"
+  className="y-suggestions-list y-hc-border y-suggestions-list--with-status y-suggestions-list--with-results"
 >
   <ul
     className="y-suggestions-list--results"
@@ -214,7 +214,7 @@ exports[`<SuggestionsList /> when isLoading=true with results with state.hovered
 
 exports[`<SuggestionsList /> when isLoading=true without results renders as expected 1`] = `
 <div
-  className="y-suggestions-list y-suggestions-list--with-status"
+  className="y-suggestions-list y-hc-border y-suggestions-list--with-status"
 >
   <Block
     push={-2}

--- a/src/components/SuggestionsList/__snapshots__/SuggestionsListItem.test.tsx.snap
+++ b/src/components/SuggestionsList/__snapshots__/SuggestionsListItem.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<SuggestionsListItem /> when isSelected=false renders as expected 1`] = `
 <div
-  className="y-suggestions-list-item"
+  className="y-suggestions-list-item y-hc-select-on-hover y-hc-suppress-text-background"
   onMouseDown={[Function]}
 >
   <MediaObject
@@ -40,7 +40,7 @@ exports[`<SuggestionsListItem /> when isSelected=false renders as expected 1`] =
 
 exports[`<SuggestionsListItem /> when isSelected=true renders as expected 1`] = `
 <div
-  className="y-suggestions-list-item y-suggestions-list-item--selected"
+  className="y-suggestions-list-item y-hc-select-on-hover y-hc-suppress-text-background y-suggestions-list-item--selected y-hc-selected"
   onMouseDown={[Function]}
 >
   <MediaObject

--- a/src/css/high-contrast.css
+++ b/src/css/high-contrast.css
@@ -1,0 +1,51 @@
+/**
+  * Helper classes to work with Windows High Contrast mode.
+  */
+
+@media screen and (-ms-high-contrast: active) {
+  /* Add border */
+  .y-hc-border {
+    border: 1px solid WindowText !important;
+  }
+
+  /**
+    * EDGE adds background color to text nodes by default, and
+    * this causes adjacent block elements to clip one another.
+    * We work around this by using the 'adjust' property to
+    * disable the default high contrast processing. We then have
+    * to specify the text color manually.
+    */
+  .y-hc-suppress-text-background * {
+    -ms-high-contrast-adjust: none;
+    color: WindowText !important;
+  }
+
+  /** 
+    * Selection helpers:
+    * y-hc-selected forces the element and descendants to use the
+    *   'selected item' theme colors.
+    * y-hc-select-on-hover is similar, but only applies on mouse hover.
+    */
+  .y-hc-select-on-hover:hover,
+  .y-hc-selected {
+    color: HighlightText !important;
+    border-color: HighlightText !important;
+    background: Highlight !important;
+  }
+
+  /**
+    * not(body) added purely to increase specificify so that we
+    * override an !important rule coming from Fabric's persona component,
+    * which doesn't seem to anticipate that it might be used in a context
+    * where it is selected.
+    *
+    * Background is set only on the parent, and set to none on descendants
+    * to avoid introducing solid backgrounds that were previously not present.
+    */
+  .y-hc-select-on-hover:hover *,
+  .y-hc-selected:not(body) * {
+    color: HighlightText !important;
+    border-color: HighlightText !important;
+    background: none !important;
+  }
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -4,3 +4,4 @@
 @import "src/css/font-face.css";
 @import "src/css/base.css";
 @import "src/css/utility-classes.css";
+@import "src/css/high-contrast.css";


### PR DESCRIPTION
HC-specific rules added to:
* add border around the list
* use selection colors for the selected item
* avoid clipping on EDGE

Before:
![image](https://user-images.githubusercontent.com/1754373/36755635-a6781488-1bc1-11e8-9d55-4de34e52039f.png)

After:
![image](https://user-images.githubusercontent.com/1754373/36755646-afc5389a-1bc1-11e8-85d2-eac5435cc083.png)

## Pull request checklist

* [ ] Component `README.md` file is up-to-date.
* [ ] Component is unit tested.
