### PR TITLE
Add role=button to SuggestionListItem for compat with speech input

### DIFF
--- a/src/components/SuggestionsList/SuggestionsListItem.tsx
+++ b/src/components/SuggestionsList/SuggestionsListItem.tsx
@@ -48,8 +48,13 @@ export default class SuggestionsListItem extends React.PureComponent<Suggestions
     const avatar = this.getAvatar();
     const className = isSelected ? selectedClass : baseClass;
     const title = getHighlightedName(name, searchText);
+    // role=button added so that speech software knows that these are clickable targets.
     return (
-      <div onMouseDown={this.onMouseDown} className={className}>
+      <div
+        onMouseDown={this.onMouseDown}
+        className={className}
+        role="button"
+      >
         <MediaObject
           size={MediaObjectSize.SMALL}
           imageContent={avatar}

--- a/src/components/SuggestionsList/__snapshots__/SuggestionsListItem.test.tsx.snap
+++ b/src/components/SuggestionsList/__snapshots__/SuggestionsListItem.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<SuggestionsListItem /> when isSelected=false renders as expected 1`] =
 <div
   className="y-suggestions-list-item y-hc-select-on-hover y-hc-suppress-text-background"
   onMouseDown={[Function]}
+  role="button"
 >
   <MediaObject
     imageContent={
@@ -37,6 +38,7 @@ exports[`<SuggestionsListItem /> when isSelected=true renders as expected 1`] = 
 <div
   className="y-suggestions-list-item y-hc-select-on-hover y-hc-suppress-text-background y-suggestions-list-item--selected y-hc-selected"
   onMouseDown={[Function]}
+  role="button"
 >
   <MediaObject
     imageContent={
@@ -70,6 +72,7 @@ exports[`<SuggestionsListItem /> with avatarProps renders as expected 1`] = `
 <div
   className="y-suggestions-list-item y-hc-select-on-hover y-hc-suppress-text-background"
   onMouseDown={[Function]}
+  role="button"
 >
   <MediaObject
     imageContent={


### PR DESCRIPTION
Speech input apps like Nuance's Dragon look for clicable candidates by scanning for
links, buttons, and similar interactive items. Adding role=button here allows a
user to say 'click <username>' to click one of the items in the list.

*Describe the change you are making*

## Pull request checklist

* [ ] Component `README.md` file is up-to-date.
* [ ] Component is unit tested.
