### PR TITLE
fix(SuggestionListItem): Prevent SuggestionListItem from stealing focus

### DIFF
--- a/src/components/SuggestionsList/SuggestionsListItem.test.tsx
+++ b/src/components/SuggestionsList/SuggestionsListItem.test.tsx
@@ -59,13 +59,20 @@ describe('<SuggestionsListItem />', () => {
   });
 
   describe('when selecting', () => {
+    let preventDefault: jest.Mock;
+
     beforeEach(() => {
       rendered = shallow(<SuggestionsListItem {...getProps()} />);
-      rendered.simulate('mouseDown');
+      preventDefault = jest.fn();
+      rendered.simulate('mouseDown', { preventDefault });
     });
 
     it('calls props.onSelect', () => {
       expect(onSelect).toBeCalled();
+    });
+
+    it('calls event preventDefault', () => {
+      expect(preventDefault).toBeCalled();
     });
   });
 });

--- a/src/components/SuggestionsList/SuggestionsListItem.tsx
+++ b/src/components/SuggestionsList/SuggestionsListItem.tsx
@@ -76,8 +76,9 @@ export default class SuggestionsListItem extends React.PureComponent<Suggestions
     return <Avatar {...props} />;
   }
 
-  private onMouseDown = () => {
+  private onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     const { onSelect, children, className, ...item } = this.props;
+    e.preventDefault();
     this.props.onSelect(item.id);
   };
 }


### PR DESCRIPTION
When clicking SuggestionListItems the mousedown event should be preventDefault’d so the focused item in the page doesn’t get blurred

