### PR TITLE
WIP: Focus outlines: PR for initial review only.

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -222,7 +222,12 @@ export default class Button extends React.Component<ButtonProps> {
   private getClasses() {
     const { className, color, status, size, fullWidth } = this.props;
 
-    const classes: string[] = ['y-button', `y-button__color-${color}`, `y-button__size-${size}`];
+    const classes: string[] = [
+      'y-button',
+      `y-button__color-${color}`,
+      `y-button__size-${size}`,
+      'y-focus-high-contrast-inset',
+    ];
     if (status !== ButtonStatus.ENABLED) {
       classes.push(`y-button__state-${status}`);
     }

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Button /> set as disabled matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular y-button__state-disabled"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset y-button__state-disabled"
   classNames={Object {}}
   disabled={true}
   split={false}
@@ -22,7 +22,7 @@ exports[`<Button /> set as disabled matches its snapshot 1`] = `
 exports[`<Button /> set as loading matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular y-button__state-loading"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset y-button__state-loading"
   classNames={Object {}}
   disabled={true}
   split={false}
@@ -50,7 +50,7 @@ exports[`<Button /> set as loading matches its snapshot 1`] = `
 exports[`<Button /> with additional className matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular TEST_CLASSNAME"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset TEST_CLASSNAME"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -70,7 +70,7 @@ exports[`<Button /> with aria label matches its snapshot 1`] = `
 <BaseButton
   ariaLabel="Aria description"
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -89,7 +89,7 @@ exports[`<Button /> with aria label matches its snapshot 1`] = `
 exports[`<Button /> with button type matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -108,7 +108,7 @@ exports[`<Button /> with button type matches its snapshot 1`] = `
 exports[`<Button /> with default options matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -127,7 +127,7 @@ exports[`<Button /> with default options matches its snapshot 1`] = `
 exports[`<Button /> with fullWidth matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular y-button__fullWidth"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset y-button__fullWidth"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -146,7 +146,7 @@ exports[`<Button /> with fullWidth matches its snapshot 1`] = `
 exports[`<Button /> with icon matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -170,7 +170,7 @@ exports[`<Button /> with icon matches its snapshot 1`] = `
 exports[`<Button /> with icon on the right matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -194,7 +194,7 @@ exports[`<Button /> with icon on the right matches its snapshot 1`] = `
 exports[`<Button /> with invalid href matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   href="#"
@@ -214,7 +214,7 @@ exports[`<Button /> with invalid href matches its snapshot 1`] = `
 exports[`<Button /> with primary color matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-primary y-button__size-regular"
+  className="y-button y-button__color-primary y-button__size-regular y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -233,7 +233,7 @@ exports[`<Button /> with primary color matches its snapshot 1`] = `
 exports[`<Button /> with primary color set as loading matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-primary y-button__size-regular y-button__state-loading"
+  className="y-button y-button__color-primary y-button__size-regular y-focus-high-contrast-inset y-button__state-loading"
   classNames={Object {}}
   disabled={true}
   split={false}
@@ -261,7 +261,7 @@ exports[`<Button /> with primary color set as loading matches its snapshot 1`] =
 exports[`<Button /> with reset type matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -280,7 +280,7 @@ exports[`<Button /> with reset type matches its snapshot 1`] = `
 exports[`<Button /> with small size matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-small"
+  className="y-button y-button__color-secondary y-button__size-small y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -299,7 +299,7 @@ exports[`<Button /> with small size matches its snapshot 1`] = `
 exports[`<Button /> with small size set as loading matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-small y-button__state-loading"
+  className="y-button y-button__color-secondary y-button__size-small y-focus-high-contrast-inset y-button__state-loading"
   classNames={Object {}}
   disabled={true}
   split={false}
@@ -327,7 +327,7 @@ exports[`<Button /> with small size set as loading matches its snapshot 1`] = `
 exports[`<Button /> with small size with icon matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-small"
+  className="y-button y-button__color-secondary y-button__size-small y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -351,7 +351,7 @@ exports[`<Button /> with small size with icon matches its snapshot 1`] = `
 exports[`<Button /> with submit type matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   split={false}
@@ -370,7 +370,7 @@ exports[`<Button /> with submit type matches its snapshot 1`] = `
 exports[`<Button /> with valid href matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
-  className="y-button y-button__color-secondary y-button__size-regular"
+  className="y-button y-button__color-secondary y-button__size-regular y-focus-high-contrast-inset"
   classNames={Object {}}
   disabled={false}
   href="https://www.yammer.com"

--- a/src/components/Clickable/Clickable.css
+++ b/src/components/Clickable/Clickable.css
@@ -12,8 +12,3 @@
   border: none;
   cursor: pointer;
 }
-
-.y-clickable__block {
-  display: block;
-  width: 100%;
-}

--- a/src/components/Clickable/Clickable.md
+++ b/src/components/Clickable/Clickable.md
@@ -30,3 +30,27 @@ Unstyled block with FakeLink:
   </Clickable>
 </div>
 ```
+
+Wrapping block content:
+
+```js { "props": { "data-description": "wrapping" } }
+
+<Clickable onClick={action('clickable clicked')}  display="inlineBlock">
+  <div>
+    This <strong>Clickable</strong> component wraps an entire block of text. By default all text content within a <strong>Clickable</strong> tag will be styled like a link.
+  </div>
+</Clickable>
+```
+
+Wrapping and sizing to child block content:
+
+```js { "props": { "data-description": "wrapping" } }
+const yammerLogo = 'logo.png';
+const yammerLogoDescription = 'Yammer "y" logo';
+
+<div>
+  <Clickable onClick={action('clickable clicked')} unstyled display="inlineBlock" focus="overlay">
+    <Image source={yammerLogo} description={yammerLogoDescription} width={320} height={240} />
+  </Clickable>
+</div>
+```

--- a/src/components/Clickable/Clickable.tsx
+++ b/src/components/Clickable/Clickable.tsx
@@ -2,6 +2,7 @@
 import '../../yamui';
 import * as React from 'react';
 import FakeLink from '../FakeLink';
+import { camelCaseToDashed } from '../../util/classNames';
 import { NestableBaseComponentProps } from '../../util/BaseComponent/props';
 import './Clickable.css';
 
@@ -15,6 +16,20 @@ export interface ClickableProps extends NestableBaseComponentProps {
    * Whether the clickable should be `display: block`.
    */
   block?: boolean;
+
+  /**
+   * Display type to use. Defaults to inline, which allows contents to wrap across lines, but can't
+   * hold block content. Use `Block` to contain block content, or `InlineBlock` to contain block
+   * and size to block content
+   */
+  display?: 'inline' | 'block' | 'inlineBlock';
+
+  /**
+   * Focus outline style to use. Defaults to using 1px inset focus. If link contains content that
+   * covers its surface, it should use displayType=BLOCK and focusType=OVERLAY so that the focus
+   * is visible and not hidden under the children.
+   */
+  focus?: 'normal' | 'overlay' | 'highContrastInset';
 
   /**
    * Title or description of the linked document.
@@ -50,15 +65,25 @@ export default class Clickable extends React.Component<ClickableProps> {
   }
 
   private getClasses() {
-    const { block, className } = this.props;
+    const { className, display, focus } = this.props;
 
     const classes: string[] = ['y-clickable'];
-    if (block) {
-      classes.push('y-clickable__block');
+    if (focus) {
+      classes.push(`y-focus-${camelCaseToDashed(focus)}`);
+    } else {
+      classes.push('y-focus-normal');
     }
+
+    if (display) {
+      classes.push(`y-display-${camelCaseToDashed(display)}`);
+    }
+
     if (className) {
       classes.push(className);
     }
+
+    // TODO: only some combinations of block + focus are valid
+    // TODO: block vs displayType
 
     return classes.join(' ');
   }

--- a/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
+++ b/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Clickable /> when ariaLabel is passed matches its snapshot 1`] = `
 <button
   aria-label="aria label content"
-  className="y-clickable"
+  className="y-clickable y-focus-normal"
   type="button"
 >
   <FakeLink>
@@ -14,7 +14,7 @@ exports[`<Clickable /> when ariaLabel is passed matches its snapshot 1`] = `
 
 exports[`<Clickable /> when block is true matches its snapshot 1`] = `
 <button
-  className="y-clickable y-clickable__block"
+  className="y-clickable y-focus-normal"
   type="button"
 >
   <FakeLink>
@@ -25,7 +25,7 @@ exports[`<Clickable /> when block is true matches its snapshot 1`] = `
 
 exports[`<Clickable /> when title is passed matches its snapshot 1`] = `
 <button
-  className="y-clickable"
+  className="y-clickable y-focus-normal"
   title="extra browser tooltip content"
   type="button"
 >
@@ -37,7 +37,7 @@ exports[`<Clickable /> when title is passed matches its snapshot 1`] = `
 
 exports[`<Clickable /> when unstyled matches its snapshot 1`] = `
 <button
-  className="y-clickable"
+  className="y-clickable y-focus-normal"
   type="button"
 >
   clickable content
@@ -46,7 +46,7 @@ exports[`<Clickable /> when unstyled matches its snapshot 1`] = `
 
 exports[`<Clickable /> with additional className matches its snapshot 1`] = `
 <button
-  className="y-clickable TEST_CLASSNAME"
+  className="y-clickable y-focus-normal TEST_CLASSNAME"
   type="button"
 >
   <FakeLink>
@@ -57,7 +57,7 @@ exports[`<Clickable /> with additional className matches its snapshot 1`] = `
 
 exports[`<Clickable /> with default options matches its snapshot 1`] = `
 <button
-  className="y-clickable"
+  className="y-clickable y-focus-normal"
   type="button"
 >
   <FakeLink>

--- a/src/components/NavigationLink/NavigationLink.md
+++ b/src/components/NavigationLink/NavigationLink.md
@@ -28,34 +28,48 @@ Unstyled link:
 </div>
 ```
 
-Link wrapping content:
+Link wrapping block content:
 
 ```js { "props": { "data-description": "wrapping" } }
-<NavigationLink href="/404.html">
+
+<NavigationLink href="/404.html" unstyled display="inlineBlock">
   <div>
     This <strong>NavigationLink</strong> component wraps an entire block of text. By default all text content within a <strong>NavigationLink</strong> tag will be styled like a link.
   </div>
 </NavigationLink>
 ```
 
-Unstyled link wrapping content:
+Unstyled link wrapping block content:
 
 ```js { "props": { "data-description": "unstyled wrapping" } }
 const { TextColor } = require('../Text');
 
 <div>
-  <NavigationLink href="/404.html" unstyled>
+  <NavigationLink href="/404.html" unstyled display="inlineBlock">
     <div>
       This is an unstyled <strong>NavigationLink</strong> component wrapping an entire block of text.
     </div>
   </NavigationLink>
   <br />
-  <NavigationLink href="/404.html" unstyled>
+  <NavigationLink href="/404.html" unstyled display="inlineBlock">
     <div>
       <Text color={TextColor.METADATA}>
         This is another unstyled <strong>NavigationLink</strong> component wrapping a block of text with a different color.
       </Text>
     </div>
+  </NavigationLink>
+</div>
+```
+
+Link wrapping and sizing to child block content:
+
+```js { "props": { "data-description": "wrapping" } }
+const yammerLogo = 'logo.png';
+const yammerLogoDescription = 'Yammer "y" logo';
+
+<div>
+  <NavigationLink href="/404.html" unstyled display="inlineBlock" focus="overlay">
+    <Image source={yammerLogo} description={yammerLogoDescription} width={320} height={240} />
   </NavigationLink>
 </div>
 ```

--- a/src/components/NavigationLink/NavigationLink.tsx
+++ b/src/components/NavigationLink/NavigationLink.tsx
@@ -1,7 +1,7 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import '../../yamui';
 import * as React from 'react';
-import { join } from '../../util/classNames';
+import { camelCaseToDashed, join } from '../../util/classNames';
 import { NestableBaseComponentProps } from '../../util/BaseComponent/props';
 import './NavigationLink.css';
 
@@ -26,6 +26,20 @@ export interface NavigationLinkProps extends NestableBaseComponentProps {
    * while nesting `FakeLink` components to show link and hover state visuals.
    */
   unstyled?: boolean;
+
+  /**
+   * Display type to use. Defaults to inline, which allows contents to wrap across lines, but can't
+   * hold block content. Use `Block` to contain block content, or `InlineBlock` to contain block
+   * and size to block content
+   */
+  display?: 'block' | 'inline' | 'inlineBlock';
+
+  /**
+   * Focus outline style to use. Defaults to using 1px inset focus. If link contains content that
+   * covers its surface, it should use displayType=BLOCK and focusType=OVERLAY so that the focus
+   * is visible and not hidden under the children.
+   */
+  focus?: 'normal' | 'overlay' | 'highContrastInset';
 }
 
 /**
@@ -45,15 +59,28 @@ export default class NavigationLink extends React.Component<NavigationLinkProps>
   }
 
   private getClasses() {
-    const { className, unstyled } = this.props;
+    const { className, unstyled, focus, display } = this.props;
 
     const classes: string[] = ['y-navigationLink'];
     if (unstyled) {
       classes.push('y-navigationLink__unstyled');
     }
+
+    if (focus) {
+      classes.push(`y-focus-${camelCaseToDashed(focus)}`);
+    } else {
+      classes.push('y-focus-normal');
+    }
+
+    if (display) {
+      classes.push(`y-display-${camelCaseToDashed(display)}`);
+    }
+
     if (className) {
       classes.push(className);
     }
+
+    // TODO: throw errors for incompatible cases?
 
     return join(classes);
   }

--- a/src/components/NavigationLink/__snapshots__/NavigationLink.test.tsx.snap
+++ b/src/components/NavigationLink/__snapshots__/NavigationLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<NavigationLink /> when newWindow is true matches its snapshot 1`] = `
 <a
-  className="y-navigationLink"
+  className="y-navigationLink y-focus-normal"
   href="test.html"
   rel="nofollow noopener noreferrer"
   target="_blank"
@@ -13,7 +13,7 @@ exports[`<NavigationLink /> when newWindow is true matches its snapshot 1`] = `
 
 exports[`<NavigationLink /> when unstyled matches its snapshot 1`] = `
 <a
-  className="y-navigationLink y-navigationLink__unstyled"
+  className="y-navigationLink y-navigationLink__unstyled y-focus-normal"
   href="test.html"
 >
   link content
@@ -22,7 +22,7 @@ exports[`<NavigationLink /> when unstyled matches its snapshot 1`] = `
 
 exports[`<NavigationLink /> with additional className matches its snapshot 1`] = `
 <a
-  className="y-navigationLink TEST_CLASSNAME"
+  className="y-navigationLink y-focus-normal TEST_CLASSNAME"
   href="test.html"
 >
   test content
@@ -31,7 +31,7 @@ exports[`<NavigationLink /> with additional className matches its snapshot 1`] =
 
 exports[`<NavigationLink /> with default options matches its snapshot 1`] = `
 <a
-  className="y-navigationLink"
+  className="y-navigationLink y-focus-normal"
   href="test.html"
 >
   link content
@@ -40,7 +40,7 @@ exports[`<NavigationLink /> with default options matches its snapshot 1`] = `
 
 exports[`<NavigationLink /> with title matches its snapshot 1`] = `
 <a
-  className="y-navigationLink"
+  className="y-navigationLink y-focus-normal"
   href="test.html"
   title="TITLE CONTENT"
 >

--- a/src/css/focus-outline.css
+++ b/src/css/focus-outline.css
@@ -1,0 +1,112 @@
+/**
+  * Helper classes to manage focus outlines
+  *
+  * Focus outlines are only visible when the .is-focusVisible style is set
+  * on some ancestor: we rely on the <Fabric> root element to supply this.
+  *
+  * These only take effect if used within a <Fabric> component, or an element
+  * with .use-focusVisible set. If used outside of these, we leave the defaul
+  * browswer focus style in effect.
+  */
+
+/*
+ * y-focus-normal:
+ * Use to get focus rectangle using an inset box shadow.
+ * 
+ * This is more robust to clipping than browser default focus, as it's inset.
+ * It also provides a more reliable contrast, since it uses the text color, which
+ * should already meet 4.5:1.
+ *
+ * Can be used on inline or block elements.
+ */
+
+.ms-Fabric .y-focus-normal,
+.use-focusVisible .y-focus-normal {
+  outline: none;
+}
+
+.ms-Fabric.is-focusVisible .y-focus-normal:focus,
+.use-focusVisible.is-focusVisible .y-focus-normal:focus {
+  box-shadow: inset 0 0 0 1px;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .ms-Fabric.is-focusVisible .y-focus-normal:focus,
+  .use-focusVisible.is-focusVisible .y-focus-normal:focus {
+    box-shadow: inset 0 0 0 1px;
+  }
+}
+
+/*
+ * y-focus-high-contrast-inset:
+ * Use on items with borders to get extra clearance in Windows High Contrast mode
+ * 
+ * In Windows High Contrast mode, some button-link controls with light borders
+ * end up with stronger borders, making it hard to see a 1px inset focus outline.
+ *
+ * This style adds extra pixel inset in HC mode, so that the focus box is clearly
+ * distinct from the border box.
+ */
+
+.ms-Fabric .y-focus-high-contrast-inset,
+.use-focusVisible .y-focus-high-contrast-inset {
+  outline: none;
+}
+
+.ms-Fabric.is-focusVisible .y-focus-high-contrast-inset:focus,
+.use-focusVisible.is-focusVisible .y-focus-high-contrast-inset:focus {
+  box-shadow: inset 0 0 0 1px;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .ms-Fabric.is-focusVisible .y-focus-high-contrast-inset:focus,
+  .use-focusVisible.is-focusVisible .y-focus-high-contrast-inset:focus {
+    box-shadow: inset 0 0 0 1px Window, inset 0 0 0 2px;
+  }
+}
+
+/*
+ * y-focus-overlay:
+ * Use on items that contain opaque children that cover the element's
+ * surface.
+ * 
+ * Examples include buttons or links that wrap tight around a child
+ * image.
+ *
+ * In those cases, outlines are clipped, and inset borders are covered
+ * by the child image.
+ *
+ * This style creates an outline higher in the z-index that's overlaid
+ * on top of the child content, so is still visible.
+ *
+ * Owning control must also be using display:block or display:flex so
+ * that relative positioning works properly.
+ */
+
+.ms-Fabric .y-focus-overlay,
+.use-focusVisible .y-focus-overlay {
+  position: relative;
+  outline: none;
+}
+
+.ms-Fabric.is-focusVisible .y-focus-overlay:focus::after,
+.use-focusVisible.is-focusVisible .y-focus-overlay:focus::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  box-shadow: inset 0 0 0 1px white, inset 0 0 0 2px black, inset 0 0 0 3px white;
+  pointer-events: none;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  /* Use thicker version in high contrast mode, so that it's visually distinct from
+   * a regular box border.
+   */
+  .ms-Fabric.is-focusVisible .y-focus-overlay:focus::after,
+  .use-focusVisible.is-focusVisible .y-focus-overlay:focus::after {
+    box-shadow: inset 0 0 0 1px Window, inset 0 0 0 3px WindowText, inset 0 0 0 4px Window;
+  }
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,7 +1,8 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
-@import "normalize.css";
-@import "src/css/reset.css";
-@import "src/css/font-face.css";
-@import "src/css/base.css";
-@import "src/css/utility-classes.css";
-@import "src/css/high-contrast.css";
+@import 'normalize.css';
+@import 'src/css/reset.css';
+@import 'src/css/font-face.css';
+@import 'src/css/base.css';
+@import 'src/css/utility-classes.css';
+@import 'src/css/high-contrast.css';
+@import 'src/css/focus-outline.css';

--- a/src/css/utility-classes.css
+++ b/src/css/utility-classes.css
@@ -2,8 +2,7 @@
   * Shared CSS classes. This file should remain very small, and possibly
   * become unnecessary if we embrace a CSS-in-JS solution.
   */
-@import "src/css/variables/fonts.css";
-
+@import 'src/css/variables/fonts.css';
 
 /* Font sizes */
 .y-textSize-xxLarge {
@@ -26,4 +25,15 @@
 }
 .y-textSize-xSmall {
   @extend text__xSmall;
+}
+
+/* Display overrides */
+.y-display-block {
+  display: block;
+}
+.y-display-inline {
+  display: inline;
+}
+.y-display-inline-block {
+  display: inline-block;
 }

--- a/src/util/classNames.ts
+++ b/src/util/classNames.ts
@@ -8,3 +8,7 @@ export const join = (classNames: ClassName[]): string => {
 
   return classNames.filter(className => !!className).join(' ');
 };
+
+// Transform somethingLikeThis to something-like-this
+export const camelCaseToDashed: (className: string) => string = className =>
+  className.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);


### PR DESCRIPTION
Work in progress adding focus outline support to be consistent with Fabric.
   
- add utility classes in focus-outline.css that manage the actual CSS work,
including only displaying when Fabric's .is-focusVisible is set.
    
- Update Button to use these as-is,
    
- Update Clickable and NavigationLink to use these, and also take
 display and focus options for fine tuining depending on whether
 these contain block or inline content. Also updated .md files
  with examples.
    
Outstanding work items:
- test coverage
- image diffs
- bumping rev etc.
- fix issue with NavigationLink containing Image - this ends up with extra
     inline line padding at bottom. Need to add display=block option to Image?