### PR TITLE
bump office-ui-fabric-react to 5.85.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,9 @@
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.7.41",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.41.tgz",
-      "integrity": "sha1-M1irY3Y+fww3x4NTL0WtCsHC23s="
+      "version": "1.7.53",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.53.tgz",
+      "integrity": "sha1-J7KoW8wJdoyOwrZS/9mIBCeah8U="
     },
     "@types/cheerio": {
       "version": "0.22.7",
@@ -113,40 +113,39 @@
       }
     },
     "@uifabric/icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.6.0.tgz",
-      "integrity": "sha512-yF7px9hFI6Pif/cvA1WLVNlXrdFU4ap9ivng17JTJ8Lt709NyuSyhvrrFiGhRnBlRhkBmOGoJHrgtT494TKLYQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.7.1.tgz",
+      "integrity": "sha512-UwfDU6A0bj/QAdTsO20g9mrKXo3zxvumkBWx0F0sEHn1DF/IQDiq4zYVBjRZ3NikQe2o7koWe3Gb0NR84Qr2Sg==",
       "requires": {
-        "@uifabric/styling": "5.19.1",
+        "@uifabric/styling": "5.25.0",
         "tslib": "1.8.1"
       }
     },
     "@uifabric/merge-styles": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.13.0.tgz",
-      "integrity": "sha512-F45U4pVJbXYmP4pSXdSGa7uq9JhsaYovuA1COb7wXCgv4NWIRqdofTLGFF6rvVddK4hXxWN55ANo2DZUCU+CgA==",
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.15.2.tgz",
+      "integrity": "sha512-EF8V6s5vBh7jQ8WH3cCLCpIU6Z0yy05tV0eSY5YKIpQ7BB6E228Ty96U2WvA9ZNCHVM2iyf0ZeX+ooHlEvpKIg==",
       "requires": {
         "tslib": "1.8.1"
       }
     },
     "@uifabric/styling": {
-      "version": "5.19.1",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.19.1.tgz",
-      "integrity": "sha512-nWDnxLEDuTbFUqsOM7gMg8smAGVL2VbPanhKc7OYcqHsUAwBf8bIldCDrG6HAoCjCGvggcqP7RBlttFo0fbmdQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.25.0.tgz",
+      "integrity": "sha512-jcu4m2OOWxATy5PxxYcGU/k0K4y/eS4EVyJeyjhU19kERoqWl9dJ+ZfIPVDEcIf6dSg6twpvIWwz3xT5pG/vjA==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.41",
-        "@uifabric/merge-styles": "5.13.0",
-        "@uifabric/utilities": "5.18.2",
+        "@microsoft/load-themed-styles": "1.7.53",
+        "@uifabric/merge-styles": "5.15.2",
+        "@uifabric/utilities": "5.25.0",
         "tslib": "1.8.1"
       }
     },
     "@uifabric/utilities": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.18.2.tgz",
-      "integrity": "sha512-UXA2kf/J7dJj6//kzGgQDSDzMct4IGO5tQp8R8/B30993MhsOy3qAsN8uceklyXaz8HpWwBTrXkZ1IJVRlofFw==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.25.0.tgz",
+      "integrity": "sha512-CW2gZklqbyCp9BJFDdvYJ+V+xTlutZKq9oNSxQqh2owJZEYsca8woVvEUf/9Xzcbs9pg6Fs2IZCQbHZ/MFSXLw==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.41",
-        "@uifabric/merge-styles": "5.13.0",
+        "@uifabric/merge-styles": "5.15.2",
         "prop-types": "15.6.0",
         "tslib": "1.8.1"
       }
@@ -11973,15 +11972,15 @@
       "dev": true
     },
     "office-ui-fabric-react": {
-      "version": "5.64.4",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.64.4.tgz",
-      "integrity": "sha512-3C9RksNmfvGlwav78gYViP80NA+sBRwIdFHNC1qwTg9qf64DjZHqtUWOSv7GmQiB9gLGfmp24fpMB12IcKVZBA==",
+      "version": "5.85.0",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.85.0.tgz",
+      "integrity": "sha512-upb5kjPSlPUSPhpEnxEu8Y0DntzXFyfr6qJvZDYVAX8jabGstCFSzuI7hKEmwnmNt7f7axTVvJilqZjJpxTrEQ==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.41",
-        "@uifabric/icons": "5.6.0",
-        "@uifabric/merge-styles": "5.13.0",
-        "@uifabric/styling": "5.19.1",
-        "@uifabric/utilities": "5.18.2",
+        "@microsoft/load-themed-styles": "1.7.53",
+        "@uifabric/icons": "5.7.1",
+        "@uifabric/merge-styles": "5.15.2",
+        "@uifabric/styling": "5.25.0",
+        "@uifabric/utilities": "5.25.0",
         "prop-types": "15.6.0",
         "tslib": "1.8.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yamui",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -136,14 +136,14 @@
       "requires": {
         "@microsoft/load-themed-styles": "1.7.53",
         "@uifabric/merge-styles": "5.15.2",
-        "@uifabric/utilities": "5.25.0",
+        "@uifabric/utilities": "5.26.0",
         "tslib": "1.8.1"
       }
     },
     "@uifabric/utilities": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.25.0.tgz",
-      "integrity": "sha512-CW2gZklqbyCp9BJFDdvYJ+V+xTlutZKq9oNSxQqh2owJZEYsca8woVvEUf/9Xzcbs9pg6Fs2IZCQbHZ/MFSXLw==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.26.0.tgz",
+      "integrity": "sha512-oGPsOizNb6uU+hq9lFGvT4q+zTi2T5vSGF1dSFldbrDe4j1d6GCUX4UB7wIvBbXnt9SKJRg6a5jtP6biaaDbAQ==",
       "requires": {
         "@uifabric/merge-styles": "5.15.2",
         "prop-types": "15.6.0",
@@ -11980,7 +11980,7 @@
         "@uifabric/icons": "5.7.1",
         "@uifabric/merge-styles": "5.15.2",
         "@uifabric/styling": "5.25.0",
-        "@uifabric/utilities": "5.25.0",
+        "@uifabric/utilities": "5.26.0",
         "prop-types": "15.6.0",
         "tslib": "1.8.1"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yamui",
   "productName": "YamUI",
   "description": "UI component framework for Yammer.com",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "style": "dist/yamui-base.css",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "normalize.css": "6.0.0",
-    "office-ui-fabric-react": "5.64.4",
+    "office-ui-fabric-react": "5.85.0",
     "react-intersection-observer": "3.0.2"
   },
   "devDependencies": {

--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -56,3 +56,7 @@
 .y-avatar__borderType-soft .ms-Image {
   border-radius: $borderRadius__soft;
 }
+
+.y-avatar__size-xLarge .ms-Persona-initials {
+  line-height: 70px;
+}

--- a/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -4,12 +4,10 @@ exports[`<Avatar /> accessible text with badge description matches its snapshot 
 <div
   className="y-avatar y-avatar__size-medium"
 >
-  <PersonaCoin
+  <StyledCustomizedPersonaCoin
     hidePersonaDetails={true}
-    imageAlt=""
     imageShouldFadeIn={false}
     imageUrl="test.jpg"
-    presence={0}
     primaryText="NAME"
     size={12}
   />
@@ -23,12 +21,10 @@ exports[`<Avatar /> accessible text without badge description matches its snapsh
 <div
   className="y-avatar y-avatar__size-medium"
 >
-  <PersonaCoin
+  <StyledCustomizedPersonaCoin
     hidePersonaDetails={true}
-    imageAlt=""
     imageShouldFadeIn={false}
     imageUrl="test.jpg"
-    presence={0}
     primaryText="NAME"
     size={12}
   />
@@ -42,12 +38,10 @@ exports[`<Avatar /> with additional className matches its snapshot 1`] = `
 <div
   className="y-avatar y-avatar__size-medium TEST_CLASSNAME"
 >
-  <PersonaCoin
+  <StyledCustomizedPersonaCoin
     hidePersonaDetails={true}
-    imageAlt=""
     imageShouldFadeIn={false}
     imageUrl="test.jpg"
-    presence={0}
     primaryText="NAME"
     size={12}
   />
@@ -61,12 +55,10 @@ exports[`<Avatar /> with badge content matches its snapshot 1`] = `
 <div
   className="y-avatar y-avatar__size-xSmall"
 >
-  <PersonaCoin
+  <StyledCustomizedPersonaCoin
     hidePersonaDetails={true}
-    imageAlt=""
     imageShouldFadeIn={false}
     imageUrl="test.jpg"
-    presence={0}
     primaryText="NAME"
     size={10}
   />
@@ -87,12 +79,10 @@ exports[`<Avatar /> with image url matches its snapshot 1`] = `
 <div
   className="y-avatar y-avatar__size-medium"
 >
-  <PersonaCoin
+  <StyledCustomizedPersonaCoin
     hidePersonaDetails={true}
-    imageAlt=""
     imageShouldFadeIn={false}
     imageUrl="test.jpg"
-    presence={0}
     primaryText="NAME"
     size={12}
   />
@@ -106,12 +96,10 @@ exports[`<Avatar /> with size matches its snapshot 1`] = `
 <div
   className="y-avatar y-avatar__size-xLarge"
 >
-  <PersonaCoin
+  <StyledCustomizedPersonaCoin
     hidePersonaDetails={true}
-    imageAlt=""
     imageShouldFadeIn={false}
     imageUrl="test.jpg"
-    presence={0}
     primaryText="NAME"
     size={14}
   />
@@ -125,12 +113,10 @@ exports[`<Avatar /> with soft border type matches its snapshot 1`] = `
 <div
   className="y-avatar y-avatar__size-medium y-avatar__borderType-soft"
 >
-  <PersonaCoin
+  <StyledCustomizedPersonaCoin
     hidePersonaDetails={true}
-    imageAlt=""
     imageShouldFadeIn={false}
     imageUrl="test.jpg"
-    presence={0}
     primaryText="NAME"
     size={12}
   />
@@ -144,11 +130,9 @@ exports[`<Avatar /> with too many characters matches its snapshot 1`] = `
 <div
   className="y-avatar y-avatar__size-medium"
 >
-  <PersonaCoin
+  <StyledCustomizedPersonaCoin
     hidePersonaDetails={true}
-    imageAlt=""
     imageShouldFadeIn={false}
-    presence={0}
     primaryText="First Last"
     size={12}
   />

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`<Button /> set as disabled matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular y-button__state-disabled"
-  classNames={Object {}}
   disabled={true}
   split={false}
   styles={Object {}}
@@ -27,7 +26,6 @@ exports[`<Button /> set as loading matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular y-button__state-loading"
-  classNames={Object {}}
   disabled={true}
   split={false}
   styles={Object {}}
@@ -59,7 +57,6 @@ exports[`<Button /> with additional className matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular TEST_CLASSNAME"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -83,7 +80,6 @@ exports[`<Button /> with aria label matches its snapshot 1`] = `
   ariaLabel="Aria description"
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -106,7 +102,6 @@ exports[`<Button /> with button type matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -129,7 +124,6 @@ exports[`<Button /> with default options matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -152,7 +146,6 @@ exports[`<Button /> with fullWidth matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular y-button__fullWidth"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -175,7 +168,6 @@ exports[`<Button /> with icon matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -209,7 +201,6 @@ exports[`<Button /> with icon on the right matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -243,7 +234,6 @@ exports[`<Button /> with invalid href matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular"
-  classNames={Object {}}
   disabled={false}
   href="#"
   split={false}
@@ -267,7 +257,6 @@ exports[`<Button /> with primary color matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-primary y-button__size-regular"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -290,7 +279,6 @@ exports[`<Button /> with primary color set as loading matches its snapshot 1`] =
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-primary y-button__size-regular y-button__state-loading"
-  classNames={Object {}}
   disabled={true}
   split={false}
   styles={Object {}}
@@ -322,7 +310,6 @@ exports[`<Button /> with reset type matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -345,7 +332,6 @@ exports[`<Button /> with small size matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-small"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -368,7 +354,6 @@ exports[`<Button /> with small size set as loading matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-small y-button__state-loading"
-  classNames={Object {}}
   disabled={true}
   split={false}
   styles={Object {}}
@@ -400,7 +385,6 @@ exports[`<Button /> with small size with icon matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-small"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -434,7 +418,6 @@ exports[`<Button /> with submit type matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular"
-  classNames={Object {}}
   disabled={false}
   split={false}
   styles={Object {}}
@@ -457,7 +440,6 @@ exports[`<Button /> with valid href matches its snapshot 1`] = `
 <BaseButton
   baseClassName="ms-Button"
   className="y-button y-button__color-secondary y-button__size-regular"
-  classNames={Object {}}
   disabled={false}
   href="https://www.yammer.com"
   split={false}

--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -28,6 +28,7 @@
 
 .y-dropdown .ms-Dropdown-item {
   padding: 0.4rem 1.1rem 0.6rem;
+  text-align: left;
 }
 
 .y-dropdown .ms-Dropdown-item:hover,

--- a/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Fabric /> with default options renders 1`] = `
 <div
-  class="ms-Fabric css-32"
+  class="ms-Fabric root-33"
 >
   wrapped content
 </div>

--- a/src/components/MenuButton/MenuButton.css
+++ b/src/components/MenuButton/MenuButton.css
@@ -1,50 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 @import 'src/css/variables/colors.css';
 
-.y-menu-button.ms-Button {
-  border: 0;
-  padding: 0;
-  opacity: 0.7;
-  color: $textColor__secondary;
-}
-.y-menu-button.y-menu-button--12 {
-  height: 12px;
-  width: 12px;
-}
-.y-menu-button.y-menu-button--14 {
-  height: 14px;
-  width: 14px;
-}
-.y-menu-button.y-menu-button--16 {
-  height: 16px;
-  width: 16px;
-}
-.y-menu-button.y-menu-button--20 {
-  height: 20px;
-  width: 20px;
-}
-.y-menu-button.y-menu-button--24 {
-  height: 24px;
-  width: 24px;
-}
-.y-menu-button.y-menu-button--32 {
-  height: 32px;
-  width: 32px;
-}
-
-.y-menu-button.y-menu-button:hover,
-.y-menu-button.y-menu-button:active,
-.y-menu-button.y-menu-button:focus {
-  color: $linkColor;
-  opacity: 1;
-  background-color: transparent;
-}
-
-.y-menu-button.is-expanded {
-  color: $linkColor;
-  opacity: 1;
-}
-
 .y-menu-button--callout {
   border-radius: 1px;
 }

--- a/src/components/MenuButton/MenuButton.css
+++ b/src/components/MenuButton/MenuButton.css
@@ -1,42 +1,43 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 @import 'src/css/variables/colors.css';
 
-.y-menu-button {
+.y-menu-button.ms-Button {
   border: 0;
   padding: 0;
   opacity: 0.7;
   color: $textColor__secondary;
 }
-.y-menu-button--12 {
+.y-menu-button.y-menu-button--12 {
   height: 12px;
   width: 12px;
 }
-.y-menu-button--14 {
+.y-menu-button.y-menu-button--14 {
   height: 14px;
   width: 14px;
 }
-.y-menu-button--16 {
+.y-menu-button.y-menu-button--16 {
   height: 16px;
   width: 16px;
 }
-.y-menu-button--20 {
+.y-menu-button.y-menu-button--20 {
   height: 20px;
   width: 20px;
 }
-.y-menu-button--24 {
+.y-menu-button.y-menu-button--24 {
   height: 24px;
   width: 24px;
 }
-.y-menu-button--32 {
+.y-menu-button.y-menu-button--32 {
   height: 32px;
   width: 32px;
 }
 
-.y-menu-button:hover,
-.y-menu-button:active,
-.y-menu-button:focus {
+.y-menu-button.y-menu-button:hover,
+.y-menu-button.y-menu-button:active,
+.y-menu-button.y-menu-button:focus {
   color: $linkColor;
   opacity: 1;
+  background-color: transparent;
 }
 
 .y-menu-button.is-expanded {

--- a/src/components/MenuButton/MenuButton.tsx
+++ b/src/components/MenuButton/MenuButton.tsx
@@ -9,6 +9,7 @@ import {
 } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { join } from '../../util/classNames';
 import { BaseComponentProps } from '../../util/BaseComponent/props';
+import Colors from '../../util/colors';
 import { IconButton, IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { IconSize, BaseIcon } from '../Icon';
 import MoreIcon from '../Icon/icons/More';
@@ -154,20 +155,20 @@ export default class MenuButton extends React.Component<MenuButtonProps> {
         opacity: 0.7,
         width: `${this.props.iconSize}px`,
         height: `${this.props.iconSize}px`,
-        color: '#495361',
+        color: Colors.button,
       },
       rootHovered: {
         backgroundColor: 'transparent',
-        color: '#386cbb',
+        color: Colors.buttonHovered,
         opacity: 1,
       },
       rootPressed: {
         backgroundColor: 'transparent',
-        color: '#386cbb',
+        color: Colors.buttonPressed,
         opacity: 1,
       },
       rootExpanded: {
-        color: '#386cbb',
+        color: Colors.buttonExpanded,
         opacity: 1,
       },
     };

--- a/src/components/MenuButton/MenuButton.tsx
+++ b/src/components/MenuButton/MenuButton.tsx
@@ -9,7 +9,7 @@ import {
 } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { join } from '../../util/classNames';
 import { BaseComponentProps } from '../../util/BaseComponent/props';
-import { IconButton } from 'office-ui-fabric-react/lib/Button';
+import { IconButton, IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { IconSize, BaseIcon } from '../Icon';
 import MoreIcon from '../Icon/icons/More';
 import MenuButtonItem from './MenuButtonItem';
@@ -97,6 +97,7 @@ export default class MenuButton extends React.Component<MenuButtonProps> {
   public render() {
     return (
       <IconButton
+        styles={this.getStyles()}
         ariaLabel={this.props.ariaLabel}
         menuProps={this.getMenuProps()}
         onRenderIcon={this.getIcon}
@@ -144,4 +145,31 @@ export default class MenuButton extends React.Component<MenuButtonProps> {
   private getMenuItemContent(props: IContextualMenuItemProps) {
     return <MenuButtonItem {...props} />;
   }
+
+  private getStyles = (): IButtonStyles => {
+    return {
+      root: {
+        border: 0,
+        padding: 0,
+        opacity: 0.7,
+        width: `${this.props.iconSize}px`,
+        height: `${this.props.iconSize}px`,
+        color: '#495361',
+      },
+      rootHovered: {
+        backgroundColor: 'transparent',
+        color: '#386cbb',
+        opacity: 1,
+      },
+      rootPressed: {
+        backgroundColor: 'transparent',
+        color: '#386cbb',
+        opacity: 1,
+      },
+      rootExpanded: {
+        color: '#386cbb',
+        opacity: 1,
+      },
+    };
+  };
 }

--- a/src/components/MenuButton/MenuButton.tsx
+++ b/src/components/MenuButton/MenuButton.tsx
@@ -155,20 +155,20 @@ export default class MenuButton extends React.Component<MenuButtonProps> {
         opacity: 0.7,
         width: `${this.props.iconSize}px`,
         height: `${this.props.iconSize}px`,
-        color: Colors.button,
+        color: Colors.textSecondary,
       },
       rootHovered: {
         backgroundColor: 'transparent',
-        color: Colors.buttonHovered,
+        color: Colors.link,
         opacity: 1,
       },
       rootPressed: {
         backgroundColor: 'transparent',
-        color: Colors.buttonPressed,
+        color: Colors.link,
         opacity: 1,
       },
       rootExpanded: {
-        color: Colors.buttonExpanded,
+        color: Colors.link,
         opacity: 1,
       },
     };

--- a/src/components/MenuButton/MenuButton.tsx
+++ b/src/components/MenuButton/MenuButton.tsx
@@ -47,7 +47,7 @@ export interface MenuButtonItem {
   /**
    * On click method for this item.
    */
-  onClick?: ((ev?: React.MouseEvent<HTMLElement>) => void);
+  onClick?: ((ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void);
 
   /**
    * Href for a link. This will turn the item into a hyperlink that looks like a regular item.

--- a/src/components/MenuButton/__snapshots__/MenuButton.test.tsx.snap
+++ b/src/components/MenuButton/__snapshots__/MenuButton.test.tsx.snap
@@ -78,6 +78,32 @@ exports[`<MenuButton /> with additional classnames matches its snapshot 1`] = `
   }
   onRenderIcon={[Function]}
   onRenderMenuIcon={[Function]}
+  styles={
+    Object {
+      "root": Object {
+        "border": 0,
+        "color": "#495361",
+        "height": "20px",
+        "opacity": 0.7,
+        "padding": 0,
+        "width": "20px",
+      },
+      "rootExpanded": Object {
+        "color": "#386cbb",
+        "opacity": 1,
+      },
+      "rootHovered": Object {
+        "backgroundColor": "transparent",
+        "color": "#386cbb",
+        "opacity": 1,
+      },
+      "rootPressed": Object {
+        "backgroundColor": "transparent",
+        "color": "#386cbb",
+        "opacity": 1,
+      },
+    }
+  }
 />
 `;
 
@@ -145,6 +171,32 @@ exports[`<MenuButton /> with all props matches its snapshot 1`] = `
   }
   onRenderIcon={[Function]}
   onRenderMenuIcon={[Function]}
+  styles={
+    Object {
+      "root": Object {
+        "border": 0,
+        "color": "#495361",
+        "height": "20px",
+        "opacity": 0.7,
+        "padding": 0,
+        "width": "20px",
+      },
+      "rootExpanded": Object {
+        "color": "#386cbb",
+        "opacity": 1,
+      },
+      "rootHovered": Object {
+        "backgroundColor": "transparent",
+        "color": "#386cbb",
+        "opacity": 1,
+      },
+      "rootPressed": Object {
+        "backgroundColor": "transparent",
+        "color": "#386cbb",
+        "opacity": 1,
+      },
+    }
+  }
 />
 `;
 
@@ -212,6 +264,32 @@ exports[`<MenuButton /> with default options matches its snapshot 1`] = `
   }
   onRenderIcon={[Function]}
   onRenderMenuIcon={[Function]}
+  styles={
+    Object {
+      "root": Object {
+        "border": 0,
+        "color": "#495361",
+        "height": "20px",
+        "opacity": 0.7,
+        "padding": 0,
+        "width": "20px",
+      },
+      "rootExpanded": Object {
+        "color": "#386cbb",
+        "opacity": 1,
+      },
+      "rootHovered": Object {
+        "backgroundColor": "transparent",
+        "color": "#386cbb",
+        "opacity": 1,
+      },
+      "rootPressed": Object {
+        "backgroundColor": "transparent",
+        "color": "#386cbb",
+        "opacity": 1,
+      },
+    }
+  }
 />
 `;
 

--- a/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -1,34 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ProgressIndicator /> when complete matches its snapshot 1`] = `
-<ProgressIndicator
+<StyledProgressIndicatorBase
   ariaValueText="100% complete"
   className="y-progress-indicator"
-  description=""
-  label=""
   percentComplete={1}
-  width={180}
 />
 `;
 
 exports[`<ProgressIndicator /> when incomplete matches its snapshot 1`] = `
-<ProgressIndicator
+<StyledProgressIndicatorBase
   ariaValueText="50% complete"
   className="y-progress-indicator y-progress-indicator__incomplete"
-  description=""
-  label=""
   percentComplete={0.5}
-  width={180}
 />
 `;
 
 exports[`<ProgressIndicator /> with additional className matches its snapshot 1`] = `
-<ProgressIndicator
+<StyledProgressIndicatorBase
   ariaValueText="50% complete"
   className="y-progress-indicator y-progress-indicator__incomplete TEST_CLASS"
-  description=""
-  label=""
   percentComplete={0.5}
-  width={180}
 />
 `;

--- a/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -4,8 +4,7 @@ exports[`<Spinner /> with a color matches its snapshot 1`] = `
 <div
   className="y-spinner y-spinner__color-dark y-spinner__size-medium"
 >
-  <Spinner
-    ariaLive="polite"
+  <StyledCustomizedSpinner
     className="y-spinner--circle"
     size={2}
   />
@@ -23,8 +22,7 @@ exports[`<Spinner /> with a size matches its snapshot 1`] = `
 <div
   className="y-spinner y-spinner__color-light y-spinner__size-xSmall"
 >
-  <Spinner
-    ariaLive="polite"
+  <StyledCustomizedSpinner
     className="y-spinner--circle"
     size={0}
   />
@@ -42,8 +40,7 @@ exports[`<Spinner /> with additional className matches its snapshot 1`] = `
 <div
   className="y-spinner y-spinner__color-light y-spinner__size-medium TEST_CLASSNAME"
 >
-  <Spinner
-    ariaLive="polite"
+  <StyledCustomizedSpinner
     className="y-spinner--circle"
     size={2}
   />
@@ -61,8 +58,7 @@ exports[`<Spinner /> with invisible text matches its snapshot 1`] = `
 <div
   className="y-spinner y-spinner__color-light y-spinner__size-medium"
 >
-  <Spinner
-    ariaLive="polite"
+  <StyledCustomizedSpinner
     className="y-spinner--circle"
     size={2}
   />
@@ -76,8 +72,7 @@ exports[`<Spinner /> with visible text matches its snapshot 1`] = `
 <div
   className="y-spinner y-spinner__color-light y-spinner__size-medium"
 >
-  <Spinner
-    ariaLive="polite"
+  <StyledCustomizedSpinner
     className="y-spinner--circle"
     size={2}
   />

--- a/src/css/variables/borders.css
+++ b/src/css/variables/borders.css
@@ -6,4 +6,5 @@ $borderRadius__round: 50%;
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.2) !important;
   border: none;
   border-radius: 1px;
+  border-width: 0px !important;
 }

--- a/src/css/variables/borders.css
+++ b/src/css/variables/borders.css
@@ -6,5 +6,5 @@ $borderRadius__round: 50%;
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.2) !important;
   border: none;
   border-radius: 1px;
-  border-width: 0px !important;
+  border-width: 0 !important;
 }

--- a/src/util/colors.ts
+++ b/src/util/colors.ts
@@ -59,10 +59,8 @@ export const theme: IPartialTheme = {
  * Use for component level overrides
  */
 const colors = {
-  button: deathMetal,
-  buttonHovered: river,
-  buttonPressed: river,
-  buttonExpanded: river,
+  textSecondary: deathMetal,
+  link: river,
 };
 
 export default colors;

--- a/src/util/colors.ts
+++ b/src/util/colors.ts
@@ -1,0 +1,68 @@
+/*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
+import { IPartialTheme } from 'office-ui-fabric-react/lib/Styling';
+
+/*
+* Yammer's Color Palette - Uncomment as needed.
+*/
+
+/* Blue */
+// const blue = '#2477c3';
+// const stream = '#e9eff8';
+// const pond = '#9ac3ff';
+const lake = '#6c98d9';
+const river = '#386cbb';
+// const bay = '#264f8c';
+// const ocean = '#19345d';
+
+/* Gray */
+// const white = '#fff';
+const popRock = '#f3f5f8';
+// const altRock = '#edeff2';
+const indieRock = '#dde0e6';
+// const punkRock = '#a8b0bd';
+const heavyMetal = '#646d7a';
+const deathMetal = '#495361';
+// const blackMetal = '#343A41';
+// const black = '#000';
+
+/* Yellow */
+// const sunrise = '#ffe7b8';
+// const noon = '#ffc56c';
+// const sunset = '#f8ae41';
+
+/* Red */
+// const angel = '#fb7f78';
+const lestat = '#d1423b';
+// const dracula = '#9e3028';
+
+/* Green */
+// const leaf = '#84ca4b';
+// const tree = '#338323';
+// const forest = '#27641b';
+
+/*
+ * Used globally by Fabric
+ */
+export const theme: IPartialTheme = {
+  palette: {
+    themePrimary: lake,
+    neutralSecondary: heavyMetal,
+    neutralTertiary: indieRock,
+    neutralLighter: popRock,
+    neutralDark: indieRock,
+    redDark: lestat,
+    themeDarker: deathMetal,
+  },
+};
+
+/*
+ * Use for component level overrides
+ */
+const colors = {
+  button: deathMetal,
+  buttonHovered: river,
+  buttonPressed: river,
+  buttonExpanded: river,
+};
+
+export default colors;

--- a/src/util/fabric/theme.ts
+++ b/src/util/fabric/theme.ts
@@ -1,65 +1,42 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 
 /**
- * Override Fabric's theme variables. Note this this window.FabricConfig is temporary,
- * soon Fabric will have a loadTheme() utility to handle this.
+ * Override Fabric's theme variables.
  */
 
-import { loadTheme, IRawStyle } from 'office-ui-fabric-react/lib/Styling';
+import { loadTheme } from 'office-ui-fabric-react/lib/Styling';
+import { theme } from '../colors';
 
-const fontStyles: IRawStyle = {
-  color: '#343A41',
-};
-
-// NOTE: Would be handy to have access to our CSS variable values in JS...
 loadTheme({
-  palette: {
-    themePrimary: '#6c98d9',
-    neutralSecondary: '#646d7a',
-    neutralTertiary: '#dde0e6',
-    neutralLighter: '#f3f5f8',
-    neutralDark: '#dde0e6',
-    redDark: '#d1423b',
-  },
+  palette: theme.palette,
   fonts: {
-    tiny: fontStyles,
     xSmall: {
-      ...fontStyles,
       fontSize: '1.0rem',
       lineHeight: '1.6rem',
     },
     small: {
-      ...fontStyles,
       fontSize: '1.2rem',
       lineHeight: '1.6rem',
     },
     smallPlus: {
-      ...fontStyles,
       fontSize: '1.4rem',
       lineHeight: '2.0rem',
     },
     medium: {
-      ...fontStyles,
       fontSize: '1.5rem',
       lineHeight: '2.0rem',
     },
-    mediumPlus: fontStyles,
     large: {
-      ...fontStyles,
       fontSize: '1.8rem',
       lineHeight: '2.4rem',
     },
     xLarge: {
-      ...fontStyles,
       fontSize: '2.2rem',
       lineHeight: '2.8rem',
     },
     xxLarge: {
-      ...fontStyles,
       fontSize: '2.4rem',
       lineHeight: '2.8rem',
     },
-    superLarge: fontStyles,
-    mega: fontStyles,
   },
 });


### PR DESCRIPTION
In preparation to allow custom description's on TextField.
https://github.com/OfficeDev/office-ui-fabric-react/pull/4588


## Changes

1. Avatar - Persona initials changed line-height from 70px to 72px. Added overrided to fix.
https://github.com/OfficeDev/office-ui-fabric-react/pull/4382/files

2. MenuButton - Fabric IconButton refactor caused a change in css order. If you look at the commit history, my first fix was to use more specific selectors.  Then instead I passed the overrides in through the `styles` prop on IconButton.  I think this will generally be more maintainable, but don't feel great about the hard-coded color strings. Feedback?

3. Hovercard - .ms-Callout now has a 1px border, when we expected 0.  I've added an !important overrride here.

4. Various snapshot changes.
