### PR TITLE
Add ariaLabel to Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -33,6 +33,7 @@ describe('<Dropdown />', () => {
     beforeEach(() => {
       component = shallow(
         <Dropdown
+          ariaLabel="ARIA_LABEL"
           options={[{ key: 'A', text: 'Option a' }, { key: 'B', text: 'Option b' }]}
           className="TEST_CLASSNAME"
           selectedKey="A"

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -43,6 +43,11 @@ export interface DropdownOption {
 
 export interface DropdownProps extends BaseComponentProps {
   /**
+   * aria-label attribute
+   */
+  ariaLabel?: string;
+
+  /**
    * Items to be presented to the user.
    */
   options: DropdownOption[];
@@ -74,7 +79,7 @@ export interface DropdownProps extends BaseComponentProps {
  */
 export default class Dropdown extends React.Component<DropdownProps> {
   public render() {
-    const { className, label, placeHolder, selectedKey } = this.props;
+    const { ariaLabel, className, label, placeHolder, selectedKey } = this.props;
     const calloutProps = {
       directionalHintFixed: false,
       doNotLayer: true,
@@ -84,6 +89,7 @@ export default class Dropdown extends React.Component<DropdownProps> {
     return (
       <div className={join(['y-dropdown', className])}>
         <FabricDropdown
+          ariaLabel={ariaLabel}
           label={label}
           options={this.getFabricOptions()}
           placeHolder={placeHolder}

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -136,6 +136,7 @@ exports[`<Dropdown /> with all props matches its snapshot 1`] = `
   className="y-dropdown TEST_CLASSNAME"
 >
   <WithResponsiveMode
+    ariaLabel="ARIA_LABEL"
     calloutProps={
       Object {
         "directionalHintFixed": false,

--- a/src/components/TextArea/TextArea.test.tsx
+++ b/src/components/TextArea/TextArea.test.tsx
@@ -22,6 +22,7 @@ describe('<TextArea />', () => {
     beforeEach(() => {
       component = shallow(
         <TextArea
+          ariaLabel="ARIA_LABEL"
           rows={2}
           autoAdjustHeight={true}
           className="CLASS"

--- a/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<TextArea /> with all options matches its snapshot 1`] = `
 <TextField
   aria-required={true}
+  ariaLabel="ARIA_LABEL"
   autoAdjustHeight={true}
   borderless={false}
   className="y-base-text-field y-text-area CLASS"

--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -23,6 +23,7 @@ describe('<TextField />', () => {
     beforeEach(() => {
       component = shallow(
         <TextField
+          ariaLabel="ARIA_LABEL"
           prefix="PREFIX"
           suffix="SUFFIX"
           maxLength={100}

--- a/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<TextField /> with all options matches its snapshot 1`] = `
 <TextField
   aria-required={true}
+  ariaLabel="ARIA_LABEL"
   autoAdjustHeight={false}
   borderless={false}
   className="y-base-text-field y-text-field CLASS y-text-field--with-prefix y-text-field--with-suffix"


### PR DESCRIPTION
Will need this for some use cases in yamjs where there's no
visual label.

Also updated snapshot test for TextField + TextArea to include ariaLabel.

## Pull request checklist

* [ ] Component `README.md` file is up-to-date.
* [ ] Component is unit tested.
