### PR TITLE
Update EditableText to move focus back to the text when it exits edit…

### DIFF
--- a/src/components/BaseTextField/index.tsx
+++ b/src/components/BaseTextField/index.tsx
@@ -1,10 +1,10 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import '../../yamui';
 import * as React from 'react';
-import { BaseComponentProps } from '../../util/BaseComponent/props';
+import { BaseComponentProps, FocusableComponentProps } from '../../util/BaseComponent/props';
 import { ITextFieldProps as FabricTextFieldProps } from 'office-ui-fabric-react/lib/TextField';
 
-export interface BaseTextFieldProps extends BaseComponentProps {
+export interface BaseTextFieldProps extends BaseComponentProps, FocusableComponentProps {
   /**
    * aria-label attribute
    */

--- a/src/components/Clickable/Clickable.test.tsx
+++ b/src/components/Clickable/Clickable.test.tsx
@@ -1,7 +1,8 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { mount, ReactWrapper, shallow, ShallowWrapper } from 'enzyme';
 import Clickable, { ClickableProps } from '.';
+import { Focusable } from '../../util/Focusable';
 
 describe('<Clickable />', () => {
   let component: ShallowWrapper<ClickableProps>;
@@ -63,6 +64,38 @@ describe('<Clickable />', () => {
 
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('when focusableRef is passed', () => {
+    let mounted: ReactWrapper<ClickableProps>;
+
+    let focusable: Focusable;
+
+    beforeEach(() => {
+      const setFocusable = (f: Focusable) => {
+        focusable = f;
+      };
+      mounted = mount(<Clickable focusableRef={setFocusable}>clickable content</Clickable>);
+    });
+
+    it('matches its snapshot', () => {
+      expect(mounted).toMatchSnapshot();
+    });
+
+    describe('when focusable is used', () => {
+      let button: HTMLElement;
+
+      beforeEach(() => {
+        button = mounted.find('button').getDOMNode() as HTMLElement;
+        jest.spyOn(button, 'focus');
+
+        focusable.focus();
+      });
+
+      it('calls focus on underlying button', () => {
+        expect(button.focus).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/src/components/Clickable/Clickable.tsx
+++ b/src/components/Clickable/Clickable.tsx
@@ -2,10 +2,10 @@
 import '../../yamui';
 import * as React from 'react';
 import FakeLink from '../FakeLink';
-import { NestableBaseComponentProps } from '../../util/BaseComponent/props';
+import { NestableBaseComponentProps, FocusableComponentProps } from '../../util/BaseComponent/props';
 import './Clickable.css';
 
-export interface ClickableProps extends NestableBaseComponentProps {
+export interface ClickableProps extends NestableBaseComponentProps, FocusableComponentProps {
   /**
    * Additional label that must be provided if the clickable text is not descriptive enough.
    */
@@ -39,14 +39,37 @@ export interface ClickableProps extends NestableBaseComponentProps {
  * content in a `button` element.
  */
 export default class Clickable extends React.Component<ClickableProps> {
+  private buttonRef = React.createRef<HTMLButtonElement>();
+
+  public constructor(props: ClickableProps) {
+    super(props);
+    if (this.props.focusableRef) {
+      this.props.focusableRef(this);
+    }
+  }
+
   public render() {
     const { ariaLabel, title, unstyled, onClick, children } = this.props;
 
     return (
-      <button className={this.getClasses()} aria-label={ariaLabel} title={title} onClick={onClick} type="button">
+      <button
+        className={this.getClasses()}
+        aria-label={ariaLabel}
+        title={title}
+        onClick={onClick}
+        type="button"
+        ref={this.buttonRef}
+      >
         {unstyled ? children : <FakeLink>{children}</FakeLink>}
       </button>
     );
+  }
+
+  public focus() {
+    const button = this.buttonRef.current;
+    if (button) {
+      button.focus();
+    }
   }
 
   private getClasses() {

--- a/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
+++ b/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
@@ -23,6 +23,25 @@ exports[`<Clickable /> when block is true matches its snapshot 1`] = `
 </button>
 `;
 
+exports[`<Clickable /> when focusableRef is passed matches its snapshot 1`] = `
+<Clickable
+  focusableRef={[Function]}
+>
+  <button
+    className="y-clickable"
+    type="button"
+  >
+    <FakeLink>
+      <span
+        className="y-fakeLink"
+      >
+        clickable content
+      </span>
+    </FakeLink>
+  </button>
+</Clickable>
+`;
+
 exports[`<Clickable /> when title is passed matches its snapshot 1`] = `
 <button
   className="y-clickable"

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -3,9 +3,10 @@ import '../../yamui';
 import * as React from 'react';
 import { join } from '../../util/classNames';
 import { BaseComponentProps } from '../../util/BaseComponent/props';
+import { Focusable } from '../../util/Focusable';
 import Clickable from '../Clickable';
 import EditIcon from '../Icon/icons/Edit';
-import TextField, { TextFieldComponent } from '../TextField';
+import TextField from '../TextField';
 import { KeyCodes } from '../../util/enums';
 import './EditableText.css';
 
@@ -55,11 +56,13 @@ export interface EditableTextState {
  * Displays text which can be edited on click.
  */
 export default class EditableText extends React.Component<EditableTextProps, EditableTextState> {
-  private textFieldRef: TextFieldComponent | null;
+  private textFieldFocusable: Focusable | null;
+  private clickableFocusable: Focusable | null;
 
   constructor(props: EditableTextProps) {
     super(props);
-    this.textFieldRef = null;
+    this.textFieldFocusable = null;
+    this.clickableFocusable = null;
     this.state = { isEditing: false, editedValue: '' };
   }
 
@@ -78,7 +81,7 @@ export default class EditableText extends React.Component<EditableTextProps, Edi
             value={editedValue}
             placeHolder={placeHolder}
             maxLength={maxLength}
-            componentRef={this.setTextFieldRef}
+            focusableRef={this.setTextFieldFocusable}
             onBlur={this.commitEdit}
             onKeyDown={this.onKeyDown}
           />
@@ -93,6 +96,7 @@ export default class EditableText extends React.Component<EditableTextProps, Edi
           unstyled={true}
           className="y-editableText--clickable"
           ariaLabel={promptText}
+          focusableRef={this.setClickableFocusable}
         >
           <EditIcon />
           <span className="y-editableText--clickableText">{text || promptText}</span>
@@ -102,9 +106,14 @@ export default class EditableText extends React.Component<EditableTextProps, Edi
   }
 
   public componentDidUpdate(_prevProps: EditableTextProps, prevState: EditableTextState) {
-    // Set focus when we enter edit mode; better than depending on a hacky setTimeout()
+    // Set focus when we enter edit mode
     if (this.state.isEditing && !prevState.isEditing) {
       this.setTextFieldFocus();
+    }
+
+    // Restore focus after leaving edit mode
+    if (!this.state.isEditing && prevState.isEditing) {
+      this.setClickableFocus();
     }
   }
 
@@ -122,8 +131,12 @@ export default class EditableText extends React.Component<EditableTextProps, Edi
     }
   };
 
-  private setTextFieldRef = (component: TextFieldComponent | null) => {
-    this.textFieldRef = component;
+  private setTextFieldFocusable = (focusable: Focusable | null) => {
+    this.textFieldFocusable = focusable;
+  };
+
+  private setClickableFocusable = (focusable: Focusable) => {
+    this.clickableFocusable = focusable;
   };
 
   private updateInternalEditedDescription = (description: string) => {
@@ -131,8 +144,14 @@ export default class EditableText extends React.Component<EditableTextProps, Edi
   };
 
   private setTextFieldFocus() {
-    if (this.textFieldRef) {
-      this.textFieldRef.focus();
+    if (this.textFieldFocusable) {
+      this.textFieldFocusable.focus();
+    }
+  }
+
+  private setClickableFocus() {
+    if (this.clickableFocusable) {
+      this.clickableFocusable.focus();
     }
   }
 

--- a/src/components/EditableText/__snapshots__/EditableText.test.tsx.snap
+++ b/src/components/EditableText/__snapshots__/EditableText.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`<EditableText /> with additional className matches its snapshot 1`] = `
 >
   <Clickable
     className="y-editableText--clickable"
+    focusableRef={[Function]}
     onClick={[Function]}
     unstyled={true}
   >
@@ -23,6 +24,7 @@ exports[`<EditableText /> with all props except promptText matches its snapshot 
 >
   <Clickable
     className="y-editableText--clickable"
+    focusableRef={[Function]}
     onClick={[Function]}
     unstyled={true}
   >
@@ -42,6 +44,7 @@ exports[`<EditableText /> with all props except promptText when clicked and text
 >
   <Clickable
     className="y-editableText--clickable"
+    focusableRef={[Function]}
     onClick={[Function]}
     unstyled={true}
   >
@@ -61,6 +64,7 @@ exports[`<EditableText /> with all props except promptText when clicked and text
 >
   <Clickable
     className="y-editableText--clickable"
+    focusableRef={[Function]}
     onClick={[Function]}
     unstyled={true}
   >
@@ -80,7 +84,7 @@ exports[`<EditableText /> with all props except promptText when clicked and text
 >
   <Component
     className="y-editableText--textfield"
-    componentRef={[Function]}
+    focusableRef={[Function]}
     maxLength={120}
     onBlur={[Function]}
     onChange={[Function]}
@@ -98,7 +102,7 @@ exports[`<EditableText /> with all props except promptText when clicked enters e
 >
   <Component
     className="y-editableText--textfield"
-    componentRef={[Function]}
+    focusableRef={[Function]}
     maxLength={120}
     onBlur={[Function]}
     onChange={[Function]}
@@ -116,7 +120,7 @@ exports[`<EditableText /> with all props except promptText when clicked when tri
 >
   <Component
     className="y-editableText--textfield"
-    componentRef={[Function]}
+    focusableRef={[Function]}
     maxLength={120}
     onBlur={[Function]}
     onChange={[Function]}
@@ -134,7 +138,7 @@ exports[`<EditableText /> with all props except promptText when clicked when tri
 >
   <Component
     className="y-editableText--textfield"
-    componentRef={[Function]}
+    focusableRef={[Function]}
     maxLength={120}
     onBlur={[Function]}
     onChange={[Function]}
@@ -153,6 +157,7 @@ exports[`<EditableText /> with promptText matches its snapshot 1`] = `
   <Clickable
     ariaLabel="PROMPT TEXT"
     className="y-editableText--clickable"
+    focusableRef={[Function]}
     onClick={[Function]}
     unstyled={true}
   >
@@ -172,6 +177,7 @@ exports[`<EditableText /> without props when clicked and text is changed and ENT
 >
   <Clickable
     className="y-editableText--clickable"
+    focusableRef={[Function]}
     onClick={[Function]}
     unstyled={true}
   >
@@ -189,6 +195,7 @@ exports[`<EditableText /> without props when clicked and text is changed and ESC
 >
   <Clickable
     className="y-editableText--clickable"
+    focusableRef={[Function]}
     onClick={[Function]}
     unstyled={true}
   >

--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { shallow, ShallowWrapper, mount } from 'enzyme';
 import TextField, { TextFieldProps } from '.';
 import { TextField as FabricTextField } from 'office-ui-fabric-react/lib/TextField';
+import { Focusable } from '../../util/Focusable';
 
 describe('<TextField />', () => {
   let component: ShallowWrapper<TextFieldProps>;
@@ -40,7 +41,7 @@ describe('<TextField />', () => {
           onBlur={jest.fn().mockName('onBlur')}
           onMouseEnter={jest.fn().mockName('onMouseEnter')}
           onMouseLeave={jest.fn().mockName('onMouseLeave')}
-          componentRef={jest.fn().mockName('componentRef')}
+          focusableRef={jest.fn().mockName('focusableRef')}
         />,
       )
         .dive()
@@ -53,8 +54,8 @@ describe('<TextField />', () => {
   });
 
   describe('mounted with default options', () => {
-    let ref: any;
-    const setRef = (i: any) => (ref = i);
+    let focusable: Focusable;
+    const setFocusable = (f: Focusable) => (focusable = f);
 
     describe('when focused', () => {
       let focusSpy: jest.SpyInstance;
@@ -63,8 +64,8 @@ describe('<TextField />', () => {
       beforeEach(() => {
         focusSpy = jest.spyOn(FabricTextField.prototype, 'focus');
         setSelectionRangeSpy = jest.spyOn(FabricTextField.prototype, 'setSelectionRange');
-        mount(<TextField componentRef={setRef} />);
-        ref.focus();
+        mount(<TextField focusableRef={setFocusable} />);
+        focusable.focus();
       });
 
       it('calls focus', () => {
@@ -79,11 +80,11 @@ describe('<TextField />', () => {
 
   describe('mounted with value', () => {
     const value = 'VALUE';
-    let ref: any;
-    const setRef = (i: any) => (ref = i);
+    let focusable: Focusable;
+    const setFocusable = (f: Focusable) => (focusable = f);
 
     beforeEach(() => {
-      mount(<TextField value={value} componentRef={setRef} />);
+      mount(<TextField value={value} focusableRef={setFocusable} />);
     });
 
     describe('when focused', () => {
@@ -93,7 +94,7 @@ describe('<TextField />', () => {
       beforeEach(() => {
         focusSpy = jest.spyOn(FabricTextField.prototype, 'focus');
         setSelectionRangeSpy = jest.spyOn(FabricTextField.prototype, 'setSelectionRange');
-        ref.focus();
+        focusable.focus();
       });
 
       it('calls focus', () => {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -5,6 +5,7 @@ import { join } from '../../util/classNames';
 import { getBaseTextFieldProps, BaseTextFieldProps } from '../BaseTextField';
 import DebouncedOnChange, { DebouncedOnChangeProps, DebouncedOnChangePrivateProps } from '../../util/DebouncedOnChange';
 import { TextField as FabricTextField, ITextField } from 'office-ui-fabric-react/lib/TextField';
+import { Focusable } from '../../util/Focusable';
 
 import '../BaseTextField/BaseTextField.css';
 import './TextField.css';
@@ -26,23 +27,19 @@ export interface TextFieldProps extends BaseTextFieldProps, DebouncedOnChangePro
   underlined?: boolean;
 }
 
-export interface TextFieldComponent {
-  /**
-   * Sets focus on the input.
-   */
-  focus(): void;
-}
-
 /**
  * The TextField component enables a user to type text into an app. It's used to capture
  * a single line of text. The text displays on the screen in a simple, uniform format.
  */
-class TextField extends React.Component<TextFieldProps> implements TextFieldComponent {
+class TextField extends React.Component<TextFieldProps> implements Focusable {
   private fabricTextFieldRef: ITextField | null;
 
   public constructor(props: TextFieldProps) {
     super(props);
     this.fabricTextFieldRef = null;
+    if (this.props.focusableRef) {
+      this.props.focusableRef(this);
+    }
   }
 
   public render() {
@@ -59,7 +56,7 @@ class TextField extends React.Component<TextFieldProps> implements TextFieldComp
     );
   }
 
-  public focus = () => {
+  public focus() {
     const ref = this.fabricTextFieldRef;
     if (!ref) {
       return;
@@ -68,7 +65,7 @@ class TextField extends React.Component<TextFieldProps> implements TextFieldComp
     const valueLength = this.props.value ? this.props.value.length : 0;
     ref.focus();
     ref.setSelectionRange(valueLength, valueLength);
-  };
+  }
 
   private setRef = (node: ITextField | null) => {
     this.fabricTextFieldRef = node;

--- a/src/util/BaseComponent/props.ts
+++ b/src/util/BaseComponent/props.ts
@@ -1,4 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
+import { Focusable } from '../Focusable';
+
 export interface BaseComponentProps {
   /**
    * One or more class names to be added to the root element of this component, i.e.
@@ -12,4 +14,8 @@ export interface NestableBaseComponentProps extends BaseComponentProps {
    * Elements to be rendered as children of this component.
    */
   children?: React.ReactNode;
+}
+
+export interface FocusableComponentProps {
+  focusableRef?(ref: Focusable | null): void;
 }

--- a/src/util/DebouncedOnChange/index.tsx
+++ b/src/util/DebouncedOnChange/index.tsx
@@ -19,12 +19,6 @@ export interface DebouncedOnChangeProps {
    * @default 700
    */
   debouncedOnChangeTime?: number;
-
-  /**
-   * Optional callback to access the component interface. Use this instead of ref for accessing
-   * the public methods and properties of the component.
-   */
-  componentRef?(a: any): void;
 }
 
 export interface DebouncedOnChangePrivateProps {
@@ -32,12 +26,6 @@ export interface DebouncedOnChangePrivateProps {
    * Used to pass both onChange and debouncedOnChange to the contained component.
    */
   unifiedOnChange?: ((newValue: any) => void);
-
-  /**
-   * Optional callback to access the component.  Used to pass componentRef
-   * to the contained component.
-   */
-  ref?(a: any): void;
 }
 
 export interface NestedComponentProps {
@@ -65,8 +53,8 @@ export default class DebouncedOnChangeComponent extends React.Component<Debounce
   }
 
   public render() {
-    const { component: ComposedComponent, componentRef } = this.props;
-    return <ComposedComponent {...this.props} unifiedOnChange={this.handleChange} ref={componentRef} />;
+    const { component: ComposedComponent } = this.props;
+    return <ComposedComponent {...this.props} unifiedOnChange={this.handleChange} />;
   }
 
   public componentWillUnmount() {

--- a/src/util/Focusable.ts
+++ b/src/util/Focusable.ts
@@ -1,0 +1,7 @@
+/*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
+export interface Focusable {
+  /**
+   * Elements that are or contain a primary element that can be focused
+   */
+  focus(): void;
+}


### PR DESCRIPTION
… mode.

Also reworked how focusing works - it's no longer a special case for TextField:
- new Focsuable interface added to src/util
- FocusableComponentProps added to BaseComponent/props
- pattern established where focusable components can expose their
  Focusable interface via a focusableRef property
- Replaced the TextFieldComponent code with above Focusable
- added similar to Clickable
- now EditableText can use same techique to focus either the edit
  or the clickable text as appropriate.

*Describe the change you are making*

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [x] Component is unit tested.
