### PR TITLE
Release version 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yamui",
-  "version": "6.4.0",
+  "version": "7.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yamui",
   "productName": "YamUI",
   "description": "UI component framework for Yammer.com",
-  "version": "6.4.0",
+  "version": "7.0.0",
   "style": "dist/yamui-base.css",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bumping version. Since we're changing the name of one of the props (componentRef -> focusableRef), it's a breaking change by semver rules.

* [x] Component `README.md` file is up-to-date.
* [x] Component is unit tested.
