### PR TITLE
Bump react peer dependency to 16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "yo": "2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
     "typescript": "^2.5.0"
   },
   "scripts": {


### PR DESCRIPTION
since we're using `createRef` now