### PR TITLE
Bump Fabric to recent to restore .is-focusVisible behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,9 @@
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.7.53",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.53.tgz",
-      "integrity": "sha1-J7KoW8wJdoyOwrZS/9mIBCeah8U="
+      "version": "1.7.59",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.59.tgz",
+      "integrity": "sha1-xjsYdz1ji9gweFQHLoG2OhbXE7Y="
     },
     "@types/cheerio": {
       "version": "0.22.7",
@@ -121,35 +121,35 @@
       "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.7.1.tgz",
       "integrity": "sha512-UwfDU6A0bj/QAdTsO20g9mrKXo3zxvumkBWx0F0sEHn1DF/IQDiq4zYVBjRZ3NikQe2o7koWe3Gb0NR84Qr2Sg==",
       "requires": {
-        "@uifabric/styling": "5.25.0",
+        "@uifabric/styling": "5.30.1",
         "tslib": "1.8.1"
       }
     },
     "@uifabric/merge-styles": {
-      "version": "5.15.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.15.2.tgz",
-      "integrity": "sha512-EF8V6s5vBh7jQ8WH3cCLCpIU6Z0yy05tV0eSY5YKIpQ7BB6E228Ty96U2WvA9ZNCHVM2iyf0ZeX+ooHlEvpKIg==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.17.0.tgz",
+      "integrity": "sha512-xA4sbfKgOAx42gD56/ch8hWI6b7Gp70JM0kMnTIyF0oPWd12Lkvm5IVy1QZWxPE9YENIj5fn/mFWV2qkWKnJxQ==",
       "requires": {
         "tslib": "1.8.1"
       }
     },
     "@uifabric/styling": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.25.0.tgz",
-      "integrity": "sha512-jcu4m2OOWxATy5PxxYcGU/k0K4y/eS4EVyJeyjhU19kERoqWl9dJ+ZfIPVDEcIf6dSg6twpvIWwz3xT5pG/vjA==",
+      "version": "5.30.1",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.30.1.tgz",
+      "integrity": "sha512-FIPfljABxmhOp7f2ppR3/07D055dtAygtk5MIVhTzrJsyJuVFU560k7EyxJzXoMFptRaA3TH4obROP6qe8jQgA==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.53",
-        "@uifabric/merge-styles": "5.15.2",
-        "@uifabric/utilities": "5.26.0",
+        "@microsoft/load-themed-styles": "1.7.59",
+        "@uifabric/merge-styles": "5.17.0",
+        "@uifabric/utilities": "5.30.1",
         "tslib": "1.8.1"
       }
     },
     "@uifabric/utilities": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.26.0.tgz",
-      "integrity": "sha512-oGPsOizNb6uU+hq9lFGvT4q+zTi2T5vSGF1dSFldbrDe4j1d6GCUX4UB7wIvBbXnt9SKJRg6a5jtP6biaaDbAQ==",
+      "version": "5.30.1",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.30.1.tgz",
+      "integrity": "sha512-IbLhsCjkubLv/yAx+OxIQjXhGXxy5J7WpZMzsV9lPM6/CLXdfSkU5eX9C0FsvnGGzdaG2TzVqUFks1Z3VrqZFA==",
       "requires": {
-        "@uifabric/merge-styles": "5.15.2",
+        "@uifabric/merge-styles": "5.17.0",
         "prop-types": "15.6.0",
         "tslib": "1.8.1"
       }
@@ -11231,17 +11231,29 @@
       "dev": true
     },
     "office-ui-fabric-react": {
-      "version": "5.85.0",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.85.0.tgz",
-      "integrity": "sha512-upb5kjPSlPUSPhpEnxEu8Y0DntzXFyfr6qJvZDYVAX8jabGstCFSzuI7hKEmwnmNt7f7axTVvJilqZjJpxTrEQ==",
+      "version": "5.102.0",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.102.0.tgz",
+      "integrity": "sha512-BJjKY4rlX/uMGzTGyaMbvctyQh6kF/S+7Ma0Oc4uWU2K+rVoZXvrkAW9F2nc4/gXDYFI/quAXz+n6hOBcM86NA==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.53",
+        "@microsoft/load-themed-styles": "1.7.59",
         "@uifabric/icons": "5.7.1",
-        "@uifabric/merge-styles": "5.15.2",
-        "@uifabric/styling": "5.25.0",
-        "@uifabric/utilities": "5.26.0",
+        "@uifabric/merge-styles": "5.17.0",
+        "@uifabric/styling": "5.30.1",
+        "@uifabric/utilities": "5.31.0",
         "prop-types": "15.6.0",
         "tslib": "1.8.1"
+      },
+      "dependencies": {
+        "@uifabric/utilities": {
+          "version": "5.31.0",
+          "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.31.0.tgz",
+          "integrity": "sha512-LwkCVHBocA5BtGpm6xOPOu6NqN0xSOs3gwgIfFh3ofIvwAdKLTs04ILUXsJaN20M4j7vNHlTfEHOfxzOeoox6Q==",
+          "requires": {
+            "@uifabric/merge-styles": "5.17.0",
+            "prop-types": "15.6.0",
+            "tslib": "1.8.1"
+          }
+        }
       }
     },
     "on-finished": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "normalize.css": "6.0.0",
-    "office-ui-fabric-react": "5.85.0",
+    "office-ui-fabric-react": "5.102.0",
     "react-intersection-observer": "3.0.2"
   },
   "devDependencies": {

--- a/src/components/MenuButton/MenuButton.test.tsx
+++ b/src/components/MenuButton/MenuButton.test.tsx
@@ -56,6 +56,7 @@ describe('<MenuButton />', () => {
           checkmarkIcon: 'checkmarkIcon',
           subMenuIcon: 'subMenuIcon',
           label: 'label',
+          secondaryText: 'secondaryText',
           splitContainer: 'splitContainer',
           splitPrimary: 'splitPrimary',
           splitMenu: 'splitMenu',

--- a/src/components/MenuButton/MenuButtonItem.test.tsx
+++ b/src/components/MenuButton/MenuButtonItem.test.tsx
@@ -31,6 +31,7 @@ describe('<MenuButtonItem />', () => {
         checkmarkIcon: 'checkmarkIcon',
         subMenuIcon: 'subMenuIcon',
         label: 'label',
+        secondaryText: 'secondaryText',
         splitContainer: 'splitContainer',
         splitPrimary: 'splitPrimary',
         splitMenu: 'splitMenu',

--- a/src/components/MenuButton/__snapshots__/MenuButton.test.tsx.snap
+++ b/src/components/MenuButton/__snapshots__/MenuButton.test.tsx.snap
@@ -314,6 +314,7 @@ exports[`<MenuButton /> with default options passes contextualMenuItemAs method 
       "linkContent": "linkContent",
       "linkContentMenu": "linkContentMenu",
       "root": "root",
+      "secondaryText": "secondaryText",
       "splitContainer": "splitContainer",
       "splitMenu": "splitMenu",
       "splitPrimary": "splitPrimary",

--- a/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ProgressIndicator /> when complete matches its snapshot 1`] = `
-<StyledProgressIndicatorBase
+<StyledCustomizedProgressIndicator
   ariaValueText="100% complete"
   className="y-progress-indicator"
   percentComplete={1}
@@ -9,7 +9,7 @@ exports[`<ProgressIndicator /> when complete matches its snapshot 1`] = `
 `;
 
 exports[`<ProgressIndicator /> when incomplete matches its snapshot 1`] = `
-<StyledProgressIndicatorBase
+<StyledCustomizedProgressIndicator
   ariaValueText="50% complete"
   className="y-progress-indicator y-progress-indicator__incomplete"
   percentComplete={0.5}
@@ -17,7 +17,7 @@ exports[`<ProgressIndicator /> when incomplete matches its snapshot 1`] = `
 `;
 
 exports[`<ProgressIndicator /> with additional className matches its snapshot 1`] = `
-<StyledProgressIndicatorBase
+<StyledCustomizedProgressIndicator
   ariaValueText="50% complete"
   className="y-progress-indicator y-progress-indicator__incomplete TEST_CLASS"
   percentComplete={0.5}


### PR DESCRIPTION
Fabric used to set .is-focusVisible on root elements when keyboard
was in use. This broke in a recent version, but was restored in
5.89.0, so bumping to later than that.

## Pull request checklist

* [ ] Component `README.md` file is up-to-date.
* [ ] Component is unit tested.
