### PR TITLE
Add aria-current support to NavigationLink

### DIFF
--- a/src/components/NavigationLink/NavigationLink.test.tsx
+++ b/src/components/NavigationLink/NavigationLink.test.tsx
@@ -30,6 +30,20 @@ describe('<NavigationLink />', () => {
     });
   });
 
+  describe('with ariaCurrent', () => {
+    beforeEach(() => {
+      component = shallow(
+        <NavigationLink href="test.html" ariaCurrent="page">
+          link content
+        </NavigationLink>,
+      );
+    });
+
+    it('matches its snapshot', () => {
+      expect(component).toMatchSnapshot();
+    });
+  });
+
   describe('with ariaLabel', () => {
     beforeEach(() => {
       component = shallow(

--- a/src/components/NavigationLink/NavigationLink.tsx
+++ b/src/components/NavigationLink/NavigationLink.tsx
@@ -22,6 +22,12 @@ export interface NavigationLinkProps extends NestableBaseComponentProps {
   newWindow?: boolean;
 
   /**
+   * If present, indicates the link refers to the current page. This is usually used in cases where the link
+   * is visually styled to indicate it is selected or is the current page, such as in a navigation list.
+   */
+  ariaCurrent?: 'page';
+
+  /**
    * Title or description of the linked document for screenreaders.
    */
   ariaLabel?: string;
@@ -43,12 +49,20 @@ export interface NavigationLinkProps extends NestableBaseComponentProps {
  */
 export default class NavigationLink extends React.Component<NavigationLinkProps> {
   public render() {
-    const { ariaLabel, href, newWindow, title, children } = this.props;
+    const { ariaCurrent, ariaLabel, href, newWindow, title, children } = this.props;
     const target = newWindow ? '_blank' : undefined;
     const rel = newWindow ? 'nofollow noopener noreferrer' : undefined;
 
     return (
-      <a className={this.getClasses()} href={href} rel={rel} target={target} title={title} aria-label={ariaLabel}>
+      <a
+        className={this.getClasses()}
+        href={href}
+        rel={rel}
+        target={target}
+        title={title}
+        aria-label={ariaLabel}
+        aria-current={ariaCurrent}
+      >
         {children}
       </a>
     );

--- a/src/components/NavigationLink/__snapshots__/NavigationLink.test.tsx.snap
+++ b/src/components/NavigationLink/__snapshots__/NavigationLink.test.tsx.snap
@@ -29,6 +29,16 @@ exports[`<NavigationLink /> with additional className matches its snapshot 1`] =
 </a>
 `;
 
+exports[`<NavigationLink /> with ariaCurrent matches its snapshot 1`] = `
+<a
+  aria-current="page"
+  className="y-navigationLink"
+  href="test.html"
+>
+  link content
+</a>
+`;
+
 exports[`<NavigationLink /> with ariaLabel matches its snapshot 1`] = `
 <a
   aria-label="ARIA LABEL CONTENT"


### PR DESCRIPTION
For use in left-nav and other situations where a link is styled in such a way
to indicate that it is the current item. Screenreaders will read out
'current page' when aria-current="page" is set.

*Describe the change you are making*

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [x] Component is unit tested.
