### PR TITLE
add clickable context

### DIFF
--- a/src/components/Block/Block.css
+++ b/src/components/Block/Block.css
@@ -1,6 +1,0 @@
-/*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
-
-/* Setting full width to push out when nested in a Clickable button */
-.y-clickable .y-block {
-  width: 100%;
-}

--- a/src/components/Block/Block.styles.ts
+++ b/src/components/Block/Block.styles.ts
@@ -15,11 +15,12 @@ const getMarginTop = (topSpacing?: GutterSize, push?: number) => {
   }
 };
 
-export const getStyles = (props: BlockProps): IRawStyle => {
-  const { push, textSize, topSpacing, bottomSpacing, textAlign, textColor } = props;
+export const getStyles = (props: BlockProps & { withinClickable: boolean }): IRawStyle => {
+  const { push, textSize, topSpacing, bottomSpacing, textAlign, textColor, withinClickable } = props;
 
   return {
     textAlign,
+    width: withinClickable ? '100%' : undefined,
     color: textColor ? textColors[textColor] : undefined,
     fontSize: textSize ? fontSizes[textSize] : undefined,
     lineHeight: textSize ? lineHeights[textSize] : undefined,

--- a/src/components/Block/Block.test.tsx
+++ b/src/components/Block/Block.test.tsx
@@ -1,27 +1,21 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import { createRenderer as createShallowRenderer } from 'react-test-renderer/shallow';
+import { create as createRenderer, ReactTestRendererJSON } from 'react-test-renderer';
 import { renderIntoDocument, findRenderedDOMComponentWithClass } from 'react-dom/test-utils';
 import Block, { GutterSize, TextColor, TextSize } from '.';
+import Clickable from '../Clickable';
 
-const shallowWithContext = (jsx: JSX.Element) => {
-  const renderer = createShallowRenderer();
-  renderer.render(jsx);
-  return renderer.getRenderOutput();
-};
-
-const renderWithoutContext = (jsx: JSX.Element) => {
-  const renderedText = renderIntoDocument(jsx) as Block;
-  return findRenderedDOMComponentWithClass(renderedText, 'y-block');
+const render = (jsx: JSX.Element) => {
+  return createRenderer(jsx).toJSON();
 };
 
 describe('<Block />', () => {
-  let component: Element;
-  let componentWithContext: React.ReactElement<Block>;
+  let component: ReactTestRendererJSON | null;
+  let componentWithContext: ReactTestRendererJSON | null;
 
   describe('with default options', () => {
     beforeEach(() => {
-      componentWithContext = shallowWithContext(<Block>block content</Block>);
+      componentWithContext = render(<Block>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -31,7 +25,7 @@ describe('<Block />', () => {
 
   describe('with additional className', () => {
     beforeEach(() => {
-      component = renderWithoutContext(<Block className="TEST_CLASSNAME">block content</Block>);
+      component = render(<Block className="TEST_CLASSNAME">block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -41,7 +35,7 @@ describe('<Block />', () => {
 
   describe('with xLarge text size', () => {
     beforeEach(() => {
-      componentWithContext = shallowWithContext(<Block textSize={TextSize.XLARGE}>block content</Block>);
+      componentWithContext = render(<Block textSize={TextSize.XLARGE}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -51,7 +45,7 @@ describe('<Block />', () => {
 
   describe('with secondary textColor', () => {
     beforeEach(() => {
-      component = renderWithoutContext(<Block textColor={TextColor.SECONDARY}>block content</Block>);
+      component = render(<Block textColor={TextColor.SECONDARY}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -62,7 +56,7 @@ describe('<Block />', () => {
   describe('with textAlign', () => {
     describe('right', () => {
       beforeEach(() => {
-        component = renderWithoutContext(<Block textAlign="right">block content</Block>);
+        component = render(<Block textAlign="right">block content</Block>);
       });
 
       it('matches its snapshot', () => {
@@ -72,7 +66,7 @@ describe('<Block />', () => {
 
     describe('center', () => {
       beforeEach(() => {
-        component = renderWithoutContext(<Block textAlign="center">block content</Block>);
+        component = render(<Block textAlign="center">block content</Block>);
       });
 
       it('matches its snapshot', () => {
@@ -83,7 +77,7 @@ describe('<Block />', () => {
 
   describe('with ellipsis', () => {
     beforeEach(() => {
-      component = renderWithoutContext(<Block ellipsis={true}>block content</Block>);
+      component = render(<Block ellipsis={true}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -93,7 +87,7 @@ describe('<Block />', () => {
 
   describe('with top spacing', () => {
     beforeEach(() => {
-      component = renderWithoutContext(<Block topSpacing={GutterSize.SMALL}>block content</Block>);
+      component = render(<Block topSpacing={GutterSize.SMALL}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -103,7 +97,7 @@ describe('<Block />', () => {
 
   describe('with bottom spacing', () => {
     beforeEach(() => {
-      component = renderWithoutContext(<Block bottomSpacing={GutterSize.XLARGE}>block content</Block>);
+      component = render(<Block bottomSpacing={GutterSize.XLARGE}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -113,7 +107,7 @@ describe('<Block />', () => {
 
   describe('with padding', () => {
     beforeEach(() => {
-      component = renderWithoutContext(<Block padding={GutterSize.SMALL}>block content</Block>);
+      component = render(<Block padding={GutterSize.SMALL}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -123,7 +117,7 @@ describe('<Block />', () => {
 
   describe('with horizontal padding', () => {
     beforeEach(() => {
-      component = renderWithoutContext(<Block horizontalPadding={GutterSize.MEDIUM}>block content</Block>);
+      component = render(<Block horizontalPadding={GutterSize.MEDIUM}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -133,7 +127,7 @@ describe('<Block />', () => {
 
   describe('with vertical padding', () => {
     beforeEach(() => {
-      component = renderWithoutContext(<Block verticalPadding={GutterSize.XLARGE}>block content</Block>);
+      component = render(<Block verticalPadding={GutterSize.XLARGE}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -143,7 +137,7 @@ describe('<Block />', () => {
 
   describe('with positive push', () => {
     beforeEach(() => {
-      component = renderWithoutContext(<Block push={3}>block content</Block>);
+      component = render(<Block push={3}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -153,11 +147,27 @@ describe('<Block />', () => {
 
   describe('with negative push', () => {
     beforeEach(() => {
-      component = renderWithoutContext(<Block push={-2}>block content</Block>);
+      component = render(<Block push={-2}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('within clickable', () => {
+    let rendered: Clickable;
+
+    beforeEach(() => {
+      rendered = renderIntoDocument(
+        <Clickable>
+          <Block>block content</Block>
+        </Clickable>,
+      ) as Clickable;
+    });
+
+    it('matches its snapshot', () => {
+      expect(findRenderedDOMComponentWithClass(rendered, 'y-block')).toMatchSnapshot();
     });
   });
 });

--- a/src/components/Block/Block.test.tsx
+++ b/src/components/Block/Block.test.tsx
@@ -11,15 +11,14 @@ const render = (jsx: JSX.Element) => {
 
 describe('<Block />', () => {
   let component: ReactTestRendererJSON | null;
-  let componentWithContext: ReactTestRendererJSON | null;
 
   describe('with default options', () => {
     beforeEach(() => {
-      componentWithContext = render(<Block>block content</Block>);
+      component = render(<Block>block content</Block>);
     });
 
     it('matches its snapshot', () => {
-      expect(componentWithContext).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
     });
   });
 
@@ -35,11 +34,11 @@ describe('<Block />', () => {
 
   describe('with xLarge text size', () => {
     beforeEach(() => {
-      componentWithContext = render(<Block textSize={TextSize.XLARGE}>block content</Block>);
+      component = render(<Block textSize={TextSize.XLARGE}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
-      expect(componentWithContext).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
     });
   });
 

--- a/src/components/Block/Block.tsx
+++ b/src/components/Block/Block.tsx
@@ -3,11 +3,11 @@ import '../../yamui';
 import * as React from 'react';
 import { join } from '../../util/classNames';
 import { NestableBaseComponentProps } from '../../util/BaseComponent/props';
+import { ClickableContext } from '../Clickable';
 import { GutterSize } from '../FixedGrid/enums';
 import { TextColor, TextSize } from '../Text/enums';
 import { getStyles, getInnerStyles } from './Block.styles';
 import { mergeStyles } from '@uifabric/styling';
-import './Block.css';
 
 export { GutterSize, TextColor, TextSize };
 
@@ -83,16 +83,25 @@ export default class Block extends React.Component<BlockProps> {
     const { children, textSize } = this.props;
 
     return (
-      <BlockContext.Provider value={{ textSize }}>
-        <div className={this.getClasses()}>
-          <div className={`y-block--inner ${mergeStyles(getInnerStyles(this.props))}`}>{children}</div>
-        </div>
-      </BlockContext.Provider>
+      <ClickableContext.Consumer>
+        {clickableContext => (
+          <BlockContext.Provider value={{ textSize }}>
+            <div className={this.getClasses(clickableContext.withinClickable)}>
+              <div className={`y-block--inner ${mergeStyles(getInnerStyles(this.props))}`}>{children}</div>
+            </div>
+          </BlockContext.Provider>
+        )}
+      </ClickableContext.Consumer>
     );
   }
 
-  private getClasses() {
+  private getClasses(withinClickable: boolean) {
     const { className, textSize } = this.props;
-    return join(['y-block', textSize ? `y-textSize-${textSize}` : '', className, mergeStyles(getStyles(this.props))]);
+    return join([
+      'y-block',
+      textSize ? `y-textSize-${textSize}` : '',
+      className,
+      mergeStyles(getStyles({ ...this.props, withinClickable })),
+    ]);
   }
 }

--- a/src/components/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/components/Block/__snapshots__/Block.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`<Block /> with additional className matches its snapshot 1`] = `
 <div
-  class="y-block TEST_CLASSNAME"
+  className="y-block TEST_CLASSNAME"
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -19,14 +19,14 @@ exports[`<Block /> with additional className matches its snapshot 1`] = `
 
 exports[`<Block /> with bottom spacing matches its snapshot 1`] = `
 <div
-  class=
+  className=
       y-block
       {
         margin-bottom: 2rem;
       }
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -39,36 +39,28 @@ exports[`<Block /> with bottom spacing matches its snapshot 1`] = `
 `;
 
 exports[`<Block /> with default options matches its snapshot 1`] = `
-<Context.Provider
-  value={
-    Object {
-      "textSize": undefined,
-    }
-  }
+<div
+  className="y-block"
 >
   <div
-    className="y-block"
+    className=
+        y-block--inner
+        {
+          overflow-wrap: break-word;
+          word-wrap: break-word;
+        }
   >
-    <div
-      className=
-          y-block--inner
-          {
-            overflow-wrap: break-word;
-            word-wrap: break-word;
-          }
-    >
-      block content
-    </div>
+    block content
   </div>
-</Context.Provider>
+</div>
 `;
 
 exports[`<Block /> with ellipsis matches its snapshot 1`] = `
 <div
-  class="y-block"
+  className="y-block"
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -85,10 +77,10 @@ exports[`<Block /> with ellipsis matches its snapshot 1`] = `
 
 exports[`<Block /> with horizontal padding matches its snapshot 1`] = `
 <div
-  class="y-block"
+  className="y-block"
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -104,14 +96,14 @@ exports[`<Block /> with horizontal padding matches its snapshot 1`] = `
 
 exports[`<Block /> with negative push matches its snapshot 1`] = `
 <div
-  class=
+  className=
       y-block
       {
         margin-top: -0.2rem;
       }
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -125,10 +117,10 @@ exports[`<Block /> with negative push matches its snapshot 1`] = `
 
 exports[`<Block /> with padding matches its snapshot 1`] = `
 <div
-  class="y-block"
+  className="y-block"
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -146,14 +138,14 @@ exports[`<Block /> with padding matches its snapshot 1`] = `
 
 exports[`<Block /> with positive push matches its snapshot 1`] = `
 <div
-  class=
+  className=
       y-block
       {
         padding-top: 0.3rem;
       }
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -167,14 +159,14 @@ exports[`<Block /> with positive push matches its snapshot 1`] = `
 
 exports[`<Block /> with secondary textColor matches its snapshot 1`] = `
 <div
-  class=
+  className=
       y-block
       {
         color: #495361;
       }
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -188,14 +180,14 @@ exports[`<Block /> with secondary textColor matches its snapshot 1`] = `
 
 exports[`<Block /> with textAlign center matches its snapshot 1`] = `
 <div
-  class=
+  className=
       y-block
       {
         text-align: center;
       }
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -209,14 +201,14 @@ exports[`<Block /> with textAlign center matches its snapshot 1`] = `
 
 exports[`<Block /> with textAlign right matches its snapshot 1`] = `
 <div
-  class=
+  className=
       y-block
       {
         text-align: right;
       }
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -230,14 +222,14 @@ exports[`<Block /> with textAlign right matches its snapshot 1`] = `
 
 exports[`<Block /> with top spacing matches its snapshot 1`] = `
 <div
-  class=
+  className=
       y-block
       {
         margin-top: 0.8rem;
       }
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -251,10 +243,10 @@ exports[`<Block /> with top spacing matches its snapshot 1`] = `
 
 exports[`<Block /> with vertical padding matches its snapshot 1`] = `
 <div
-  class="y-block"
+  className="y-block"
 >
   <div
-    class=
+    className=
         y-block--inner
         {
           overflow-wrap: break-word;
@@ -269,32 +261,45 @@ exports[`<Block /> with vertical padding matches its snapshot 1`] = `
 `;
 
 exports[`<Block /> with xLarge text size matches its snapshot 1`] = `
-<Context.Provider
-  value={
-    Object {
-      "textSize": "xLarge",
-    }
-  }
+<div
+  className=
+      y-block
+      y-textSize-xLarge
+      {
+        font-size: 2.2rem;
+        line-height: 2.8rem;
+      }
 >
   <div
     className=
-        y-block
-        y-textSize-xLarge
+        y-block--inner
         {
-          font-size: 2.2rem;
-          line-height: 2.8rem;
+          overflow-wrap: break-word;
+          word-wrap: break-word;
         }
   >
-    <div
-      className=
-          y-block--inner
-          {
-            overflow-wrap: break-word;
-            word-wrap: break-word;
-          }
-    >
-      block content
-    </div>
+    block content
   </div>
-</Context.Provider>
+</div>
+`;
+
+exports[`<Block /> within clickable matches its snapshot 1`] = `
+<div
+  class=
+      y-block
+      {
+        width: 100%;
+      }
+>
+  <div
+    class=
+        y-block--inner
+        {
+          overflow-wrap: break-word;
+          word-wrap: break-word;
+        }
+  >
+    block content
+  </div>
+</div>
 `;

--- a/src/components/Clickable/Clickable.test.tsx
+++ b/src/components/Clickable/Clickable.test.tsx
@@ -73,7 +73,7 @@ describe('<Clickable />', () => {
   });
 
   describe('when focusableRef is passed', () => {
-    let mounted: HTMLElement;
+    let button: HTMLElement;
     let focusable: Focusable;
 
     beforeEach(() => {
@@ -83,22 +83,22 @@ describe('<Clickable />', () => {
       const rendered = renderIntoDocument(
         <Clickable focusableRef={setFocusable}>clickable content</Clickable>,
       ) as React.Component;
-      mounted = findRenderedDOMComponentWithClass(rendered, 'y-clickable') as HTMLElement;
+      button = findRenderedDOMComponentWithClass(rendered, 'y-clickable') as HTMLElement;
     });
 
     it('matches its snapshot', () => {
-      expect(mounted).toMatchSnapshot();
+      expect(button).toMatchSnapshot();
     });
 
     describe('when focusable is used', () => {
       beforeEach(() => {
-        jest.spyOn(mounted, 'focus');
+        jest.spyOn(button, 'focus');
 
         focusable.focus();
       });
 
       it('calls focus on underlying button', () => {
-        expect(mounted.focus).toHaveBeenCalledTimes(1);
+        expect(button.focus).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/components/Clickable/Clickable.test.tsx
+++ b/src/components/Clickable/Clickable.test.tsx
@@ -1,15 +1,20 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import { mount, ReactWrapper, shallow, ShallowWrapper } from 'enzyme';
-import Clickable, { ClickableProps } from '.';
+import Clickable from '.';
+import { create as createRenderer, ReactTestRendererJSON } from 'react-test-renderer';
+import { renderIntoDocument, Simulate, findRenderedDOMComponentWithClass } from 'react-dom/test-utils';
 import { Focusable } from '../../util/Focusable';
 
+const render = (jsx: JSX.Element) => {
+  return createRenderer(jsx).toJSON();
+};
+
 describe('<Clickable />', () => {
-  let component: ShallowWrapper<ClickableProps>;
+  let component: ReactTestRendererJSON | null;
 
   describe('with default options', () => {
     beforeEach(() => {
-      component = shallow(<Clickable>clickable content</Clickable>);
+      component = render(<Clickable>clickable content</Clickable>);
     });
 
     it('matches its snapshot', () => {
@@ -19,7 +24,7 @@ describe('<Clickable />', () => {
 
   describe('with additional className', () => {
     beforeEach(() => {
-      component = shallow(<Clickable className="TEST_CLASSNAME">clickable content</Clickable>);
+      component = render(<Clickable className="TEST_CLASSNAME">clickable content</Clickable>);
     });
 
     it('matches its snapshot', () => {
@@ -29,7 +34,7 @@ describe('<Clickable />', () => {
 
   describe('when unstyled', () => {
     beforeEach(() => {
-      component = shallow(<Clickable unstyled={true}>clickable content</Clickable>);
+      component = render(<Clickable unstyled={true}>clickable content</Clickable>);
     });
 
     it('matches its snapshot', () => {
@@ -39,7 +44,7 @@ describe('<Clickable />', () => {
 
   describe('when block is true', () => {
     beforeEach(() => {
-      component = shallow(<Clickable block={true}>clickable content</Clickable>);
+      component = render(<Clickable block={true}>clickable content</Clickable>);
     });
 
     it('matches its snapshot', () => {
@@ -49,7 +54,7 @@ describe('<Clickable />', () => {
 
   describe('when title is passed', () => {
     beforeEach(() => {
-      component = shallow(<Clickable title="extra browser tooltip content">clickable content</Clickable>);
+      component = render(<Clickable title="extra browser tooltip content">clickable content</Clickable>);
     });
 
     it('matches its snapshot', () => {
@@ -59,7 +64,7 @@ describe('<Clickable />', () => {
 
   describe('when ariaLabel is passed', () => {
     beforeEach(() => {
-      component = shallow(<Clickable ariaLabel="aria label content">clickable content</Clickable>);
+      component = render(<Clickable ariaLabel="aria label content">clickable content</Clickable>);
     });
 
     it('matches its snapshot', () => {
@@ -68,15 +73,17 @@ describe('<Clickable />', () => {
   });
 
   describe('when focusableRef is passed', () => {
-    let mounted: ReactWrapper<ClickableProps>;
-
+    let mounted: HTMLElement;
     let focusable: Focusable;
 
     beforeEach(() => {
       const setFocusable = (f: Focusable) => {
         focusable = f;
       };
-      mounted = mount(<Clickable focusableRef={setFocusable}>clickable content</Clickable>);
+      const rendered = renderIntoDocument(
+        <Clickable focusableRef={setFocusable}>clickable content</Clickable>,
+      ) as React.Component;
+      mounted = findRenderedDOMComponentWithClass(rendered, 'y-clickable') as HTMLElement;
     });
 
     it('matches its snapshot', () => {
@@ -84,33 +91,34 @@ describe('<Clickable />', () => {
     });
 
     describe('when focusable is used', () => {
-      let button: HTMLElement;
-
       beforeEach(() => {
-        button = mounted.find('button').getDOMNode() as HTMLElement;
-        jest.spyOn(button, 'focus');
+        jest.spyOn(mounted, 'focus');
 
         focusable.focus();
       });
 
       it('calls focus on underlying button', () => {
-        expect(button.focus).toHaveBeenCalledTimes(1);
+        expect(mounted.focus).toHaveBeenCalledTimes(1);
       });
     });
   });
 
   describe('when clicked', () => {
     let clicked: boolean;
+    let renderedDOM: HTMLElement;
     function clickMe() {
       clicked = true;
     }
     beforeEach(() => {
       clicked = false;
-      component = shallow(<Clickable onClick={clickMe}>clickable content</Clickable>);
+      const renderedInstance = renderIntoDocument(
+        <Clickable onClick={clickMe}>clickable content</Clickable>,
+      ) as Clickable;
+      renderedDOM = findRenderedDOMComponentWithClass(renderedInstance, 'y-clickable') as HTMLElement;
     });
 
     it('triggers its onClick callback', () => {
-      component.simulate('click');
+      Simulate.click(renderedDOM);
       expect(clicked).toBe(true);
     });
   });

--- a/src/components/Clickable/Clickable.tsx
+++ b/src/components/Clickable/Clickable.tsx
@@ -33,7 +33,11 @@ export interface ClickableProps extends NestableBaseComponentProps, FocusableCom
   onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void);
 }
 
-const defaultContext = { withinClickable: false as boolean };
+export interface ClickableContext {
+  withinClickable: boolean;
+}
+
+const defaultContext: ClickableContext = { withinClickable: false };
 
 export const ClickableContext = React.createContext(defaultContext);
 

--- a/src/components/Clickable/Clickable.tsx
+++ b/src/components/Clickable/Clickable.tsx
@@ -33,6 +33,10 @@ export interface ClickableProps extends NestableBaseComponentProps, FocusableCom
   onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void);
 }
 
+const defaultContext = { withinClickable: false as boolean };
+
+export const ClickableContext = React.createContext(defaultContext);
+
 /**
  * A `Clickable` is an accessible, clickable area that accepts arbitrary children. It is styled
  * like a link by default, but can also be unstyled. Under the hood `Clickable` simply wraps
@@ -52,16 +56,18 @@ export default class Clickable extends React.Component<ClickableProps> {
     const { ariaLabel, title, unstyled, onClick, children } = this.props;
 
     return (
-      <button
-        className={this.getClasses()}
-        aria-label={ariaLabel}
-        title={title}
-        onClick={onClick}
-        type="button"
-        ref={this.buttonRef}
-      >
-        {unstyled ? children : <FakeLink>{children}</FakeLink>}
-      </button>
+      <ClickableContext.Provider value={{ withinClickable: true }}>
+        <button
+          className={this.getClasses()}
+          aria-label={ariaLabel}
+          title={title}
+          onClick={onClick}
+          type="button"
+          ref={this.buttonRef}
+        >
+          {unstyled ? children : <FakeLink>{children}</FakeLink>}
+        </button>
+      </ClickableContext.Provider>
     );
   }
 

--- a/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
+++ b/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
@@ -6,9 +6,11 @@ exports[`<Clickable /> when ariaLabel is passed matches its snapshot 1`] = `
   className="y-clickable"
   type="button"
 >
-  <FakeLink>
+  <span
+    className="y-fakeLink"
+  >
     clickable content
-  </FakeLink>
+  </span>
 </button>
 `;
 
@@ -17,29 +19,25 @@ exports[`<Clickable /> when block is true matches its snapshot 1`] = `
   className="y-clickable y-clickable__block"
   type="button"
 >
-  <FakeLink>
+  <span
+    className="y-fakeLink"
+  >
     clickable content
-  </FakeLink>
+  </span>
 </button>
 `;
 
 exports[`<Clickable /> when focusableRef is passed matches its snapshot 1`] = `
-<Clickable
-  focusableRef={[Function]}
+<button
+  class="y-clickable"
+  type="button"
 >
-  <button
-    className="y-clickable"
-    type="button"
+  <span
+    class="y-fakeLink"
   >
-    <FakeLink>
-      <span
-        className="y-fakeLink"
-      >
-        clickable content
-      </span>
-    </FakeLink>
-  </button>
-</Clickable>
+    clickable content
+  </span>
+</button>
 `;
 
 exports[`<Clickable /> when title is passed matches its snapshot 1`] = `
@@ -48,9 +46,11 @@ exports[`<Clickable /> when title is passed matches its snapshot 1`] = `
   title="extra browser tooltip content"
   type="button"
 >
-  <FakeLink>
+  <span
+    className="y-fakeLink"
+  >
     clickable content
-  </FakeLink>
+  </span>
 </button>
 `;
 
@@ -68,9 +68,11 @@ exports[`<Clickable /> with additional className matches its snapshot 1`] = `
   className="y-clickable TEST_CLASSNAME"
   type="button"
 >
-  <FakeLink>
+  <span
+    className="y-fakeLink"
+  >
     clickable content
-  </FakeLink>
+  </span>
 </button>
 `;
 
@@ -79,8 +81,10 @@ exports[`<Clickable /> with default options matches its snapshot 1`] = `
   className="y-clickable"
   type="button"
 >
-  <FakeLink>
+  <span
+    className="y-fakeLink"
+  >
     clickable content
-  </FakeLink>
+  </span>
 </button>
 `;

--- a/src/components/PreviewCard/PreviewCard.test.tsx
+++ b/src/components/PreviewCard/PreviewCard.test.tsx
@@ -62,7 +62,7 @@ describe('<PreviewCard />', () => {
           testComponent = findRenderedComponentWithType(renderedPreviewCard, PreviewCard as React.ClassType<
             any,
             any,
-            React.ComponentClass<{}>
+            React.ComponentClass
           >).render();
         });
 
@@ -79,7 +79,7 @@ describe('<PreviewCard />', () => {
           testComponent = findRenderedComponentWithType(renderedPreviewCard, PreviewCard as React.ClassType<
             any,
             any,
-            React.ComponentClass<{}>
+            React.ComponentClass
           >).render();
         });
 

--- a/src/components/PreviewCard/PreviewCard.test.tsx
+++ b/src/components/PreviewCard/PreviewCard.test.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import Clickable from '../Clickable';
 import EditableText from '../EditableText';
-import MediaObject from '../MediaObject';
 import PreviewCard, { PreviewCardProps } from './index';
+import { renderIntoDocument, findRenderedComponentWithType } from 'react-dom/test-utils';
 
 describe('<PreviewCard />', () => {
   let component: ShallowWrapper<PreviewCardProps>;
@@ -33,9 +33,12 @@ describe('<PreviewCard />', () => {
 
   describe('when description is edible', () => {
     describe('with onDescriptionChange callback', () => {
+      let jsxComponent: JSX.Element;
+      let testComponent: React.Component;
+
       beforeEach(() => {
         onChange = jest.fn();
-        component = shallow(
+        jsxComponent = (
           <PreviewCard
             name="Filename.gif"
             description="file description"
@@ -43,37 +46,45 @@ describe('<PreviewCard />', () => {
             descriptionMaxLength={120}
             emptyEditableDescriptionText="empty placeholder text"
             onDescriptionChange={onChange}
-          />,
+          />
         );
       });
 
       it('matches its snapshot', () => {
-        expect(component).toMatchSnapshot();
+        expect(shallow(jsxComponent)).toMatchSnapshot();
       });
 
       describe('when entering edit mode', () => {
         beforeEach(() => {
-          const editableText = shallow(component.find(MediaObject).prop('metadataContent')).find(EditableText);
-          const beginEditingCallback = editableText.prop('onBeginEditing') as Function;
-          beginEditingCallback();
-          component.update();
+          const renderedPreviewCard = renderIntoDocument(jsxComponent) as PreviewCard;
+          const renderedEditableText = findRenderedComponentWithType(renderedPreviewCard, EditableText);
+          (renderedEditableText.props.onBeginEditing as Function)();
+          testComponent = findRenderedComponentWithType(renderedPreviewCard, PreviewCard as React.ClassType<
+            any,
+            any,
+            React.ComponentClass<{}>
+          >).render();
         });
 
         it('matches its snapshot', () => {
-          expect(component).toMatchSnapshot();
+          expect(testComponent).toMatchSnapshot();
         });
       });
 
       describe('when exiting edit mode', () => {
         beforeEach(() => {
-          const editableText = shallow(component.find(MediaObject).prop('metadataContent')).find(EditableText);
-          const endEditingCallback = editableText.prop('onEndEditing') as Function;
-          endEditingCallback();
-          component.update();
+          const renderedPreviewCard = renderIntoDocument(jsxComponent) as PreviewCard;
+          const renderedEditableText = findRenderedComponentWithType(renderedPreviewCard, EditableText);
+          (renderedEditableText.props.onEndEditing as Function)();
+          testComponent = findRenderedComponentWithType(renderedPreviewCard, PreviewCard as React.ClassType<
+            any,
+            any,
+            React.ComponentClass<{}>
+          >).render();
         });
 
         it('matches its snapshot', () => {
-          expect(component).toMatchSnapshot();
+          expect(testComponent).toMatchSnapshot();
         });
       });
     });

--- a/tslint.json
+++ b/tslint.json
@@ -15,6 +15,7 @@
     "insecure-random": false,
     "interface-name": [true, "never-prefix"],
     "linebreak-style": false,
+    "jsx-no-multiline-js": false,
     "match-default-export-name": false,
     "missing-jsdoc": false,
     "newline-before-return": false,
@@ -50,6 +51,7 @@
         "esSpecCompliant": true
       }
     ],
+    "react-tsx-curly-spacing": false,
     "typedef": false,
     "no-unused-expression": [true, "allow-fast-null-checks"],
     "no-redundant-jsdoc": false,


### PR DESCRIPTION
The primary goal was to remove the last of the css for the `Block` component. 

The rule is that a `Block` needs to be 100% width, when nested within a `Clickable` component.

To achieve this, I added a clickable Context Provider. 

This led to some challenges in our snapshot tests, which I've addressed to the best of my current ability, but I suspect there is room for improvement.  
