### PR TITLE
Convert yammer palette colors from hex to rgb

### DIFF
--- a/src/components/AsideSection/__snapshots__/AsideSection.test.tsx.snap
+++ b/src/components/AsideSection/__snapshots__/AsideSection.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<AsideSection /> With minimal options matches snapshot 1`] = `
       className=
 
           {
-            border-bottom: 1px solid #dde0e6;
+            border-bottom: 1px solid rgb(221,224,230);
           }
       gutterSize="small"
     >
@@ -51,7 +51,7 @@ exports[`<AsideSection /> with action prop renders the action in its own FixedGr
       className=
 
           {
-            border-bottom: 1px solid #dde0e6;
+            border-bottom: 1px solid rgb(221,224,230);
           }
       gutterSize="small"
     >
@@ -97,7 +97,7 @@ exports[`<AsideSection /> with children matches the snapshot 1`] = `
       className=
 
           {
-            border-bottom: 1px solid #dde0e6;
+            border-bottom: 1px solid rgb(221,224,230);
           }
       gutterSize="small"
     >

--- a/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -86,11 +86,11 @@ exports[`<Avatar /> with badge content matches its snapshot 1`] = `
     className=
         y-avatar--badge
         {
-          background: #ffffff;
+          background: rgb(255,255,255);
           border-radius: 50%;
-          border: solid 2px #ffffff;
+          border: solid 2px rgb(255,255,255);
           bottom: -2px;
-          color: #386cbb;
+          color: rgb(56,108,187);
           height: 16px;
           position: absolute;
           right: -2px;

--- a/src/components/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/components/Block/__snapshots__/Block.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`<Block /> with secondary textColor matches its snapshot 1`] = `
   className=
       y-block
       {
-        color: #495361;
+        color: rgb(73,83,97);
       }
 >
   <div

--- a/src/components/Box/__snapshots__/Box.test.tsx.snap
+++ b/src/components/Box/__snapshots__/Box.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`<Box /> with additional className matches its snapshot 1`] = `
       TEST_CLASSNAME
       {
         border-radius: 1px;
-        border: 1px solid #dde0e6;
+        border: 1px solid rgb(221,224,230);
       }
 >
   <Block
@@ -31,7 +31,7 @@ exports[`<Box /> with children passed matches its snapshot 1`] = `
       y-box
       {
         border-radius: 1px;
-        border: 1px solid #dde0e6;
+        border: 1px solid rgb(221,224,230);
       }
 >
   <Block
@@ -55,7 +55,7 @@ exports[`<Box /> with default options matches its snapshot 1`] = `
       y-box
       {
         border-radius: 1px;
-        border: 1px solid #dde0e6;
+        border: 1px solid rgb(221,224,230);
       }
 >
   <Block

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -9,13 +9,13 @@ exports[`<Button /> set as disabled matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "default",
         "display": "inline-block",
         "fontWeight": "600",
@@ -28,20 +28,20 @@ exports[`<Button /> set as disabled matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -69,13 +69,13 @@ exports[`<Button /> set as loading matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "default",
         "display": "inline-block",
         "fontWeight": "600",
@@ -88,20 +88,20 @@ exports[`<Button /> set as loading matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -139,13 +139,13 @@ exports[`<Button /> with additional className matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -158,20 +158,20 @@ exports[`<Button /> with additional className matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -200,13 +200,13 @@ exports[`<Button /> with aria label matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -219,20 +219,20 @@ exports[`<Button /> with aria label matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -260,13 +260,13 @@ exports[`<Button /> with button type matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -279,20 +279,20 @@ exports[`<Button /> with button type matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -320,13 +320,13 @@ exports[`<Button /> with default options matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -339,20 +339,20 @@ exports[`<Button /> with default options matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -380,13 +380,13 @@ exports[`<Button /> with fullWidth matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "block",
         "fontWeight": "600",
@@ -399,20 +399,20 @@ exports[`<Button /> with fullWidth matches its snapshot 1`] = `
         "width": "100%",
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -440,13 +440,13 @@ exports[`<Button /> with icon matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -459,20 +459,20 @@ exports[`<Button /> with icon matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -511,13 +511,13 @@ exports[`<Button /> with icon on the right matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -530,20 +530,20 @@ exports[`<Button /> with icon on the right matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -583,13 +583,13 @@ exports[`<Button /> with invalid href matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -602,20 +602,20 @@ exports[`<Button /> with invalid href matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -643,13 +643,13 @@ exports[`<Button /> with primary color matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#386cbb",
-        "borderColor": "#386cbb",
+        "backgroundColor": "rgb(56,108,187)",
+        "borderColor": "rgb(56,108,187)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#ffffff",
+        "color": "rgb(255,255,255)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -662,20 +662,20 @@ exports[`<Button /> with primary color matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#2f5c9f",
-        "borderColor": "#2f5c9f",
-        "color": "#ffffff",
+        "backgroundColor": "rgb(47,92,159)",
+        "borderColor": "rgb(47,92,159)",
+        "color": "rgb(255,255,255)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#2f5c9f",
-        "borderColor": "#2f5c9f",
-        "color": "#ffffff",
+        "backgroundColor": "rgb(47,92,159)",
+        "borderColor": "rgb(47,92,159)",
+        "color": "rgb(255,255,255)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#264f8c",
-        "borderColor": "#264f8c",
-        "color": "#ffffff",
+        "backgroundColor": "rgb(38,79,140)",
+        "borderColor": "rgb(38,79,140)",
+        "color": "rgb(255,255,255)",
       },
     }
   }
@@ -703,13 +703,13 @@ exports[`<Button /> with primary color set as loading matches its snapshot 1`] =
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#386cbb",
-        "borderColor": "#386cbb",
+        "backgroundColor": "rgb(56,108,187)",
+        "borderColor": "rgb(56,108,187)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#ffffff",
+        "color": "rgb(255,255,255)",
         "cursor": "default",
         "display": "inline-block",
         "fontWeight": "600",
@@ -722,20 +722,20 @@ exports[`<Button /> with primary color set as loading matches its snapshot 1`] =
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#2f5c9f",
-        "borderColor": "#2f5c9f",
-        "color": "#ffffff",
+        "backgroundColor": "rgb(47,92,159)",
+        "borderColor": "rgb(47,92,159)",
+        "color": "rgb(255,255,255)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#2f5c9f",
-        "borderColor": "#2f5c9f",
-        "color": "#ffffff",
+        "backgroundColor": "rgb(47,92,159)",
+        "borderColor": "rgb(47,92,159)",
+        "color": "rgb(255,255,255)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#264f8c",
-        "borderColor": "#264f8c",
-        "color": "#ffffff",
+        "backgroundColor": "rgb(38,79,140)",
+        "borderColor": "rgb(38,79,140)",
+        "color": "rgb(255,255,255)",
       },
     }
   }
@@ -773,13 +773,13 @@ exports[`<Button /> with reset type matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -792,20 +792,20 @@ exports[`<Button /> with reset type matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -833,13 +833,13 @@ exports[`<Button /> with small size matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -852,20 +852,20 @@ exports[`<Button /> with small size matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -893,13 +893,13 @@ exports[`<Button /> with small size set as loading matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "default",
         "display": "inline-block",
         "fontWeight": "600",
@@ -912,20 +912,20 @@ exports[`<Button /> with small size set as loading matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -963,13 +963,13 @@ exports[`<Button /> with small size with icon matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -982,20 +982,20 @@ exports[`<Button /> with small size with icon matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -1034,13 +1034,13 @@ exports[`<Button /> with submit type matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -1053,20 +1053,20 @@ exports[`<Button /> with submit type matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }
@@ -1095,13 +1095,13 @@ exports[`<Button /> with valid href matches its snapshot 1`] = `
   styles={
     Object {
       "root": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#dde0e6",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(221,224,230)",
         "borderRadius": "2px",
         "borderStyle": "solid",
         "borderWidth": "1px",
         "boxShadow": "0 1px 1px 0 rgba(0, 0, 0, 0.05)",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "cursor": "pointer",
         "display": "inline-block",
         "fontWeight": "600",
@@ -1114,20 +1114,20 @@ exports[`<Button /> with valid href matches its snapshot 1`] = `
         "width": undefined,
       },
       "rootFocused": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
       },
       "rootHovered": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#9ac3ff",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(154,195,255)",
+        "color": "rgb(56,108,187)",
         "textDecoration": "none",
       },
       "rootPressed": Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#6c98d9",
-        "color": "#386cbb",
+        "backgroundColor": "rgb(255,255,255)",
+        "borderColor": "rgb(108,152,217)",
+        "color": "rgb(56,108,187)",
       },
     }
   }

--- a/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Fabric /> with default options renders 1`] = `
   class=
       ms-Fabric
       {
-        color: #343A41;
+        color: rgb(52,58,65);
         font-size: 1.5rem;
         line-height: 2.0rem;
       }

--- a/src/components/MenuButton/__snapshots__/MenuButton.test.tsx.snap
+++ b/src/components/MenuButton/__snapshots__/MenuButton.test.tsx.snap
@@ -82,24 +82,24 @@ exports[`<MenuButton /> with additional classnames matches its snapshot 1`] = `
     Object {
       "root": Object {
         "border": 0,
-        "color": "#495361",
+        "color": "rgb(73,83,97)",
         "height": "20px",
         "opacity": 0.7,
         "padding": 0,
         "width": "20px",
       },
       "rootExpanded": Object {
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "opacity": 1,
       },
       "rootHovered": Object {
         "backgroundColor": "transparent",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "opacity": 1,
       },
       "rootPressed": Object {
         "backgroundColor": "transparent",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "opacity": 1,
       },
     }
@@ -175,24 +175,24 @@ exports[`<MenuButton /> with all props matches its snapshot 1`] = `
     Object {
       "root": Object {
         "border": 0,
-        "color": "#495361",
+        "color": "rgb(73,83,97)",
         "height": "20px",
         "opacity": 0.7,
         "padding": 0,
         "width": "20px",
       },
       "rootExpanded": Object {
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "opacity": 1,
       },
       "rootHovered": Object {
         "backgroundColor": "transparent",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "opacity": 1,
       },
       "rootPressed": Object {
         "backgroundColor": "transparent",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "opacity": 1,
       },
     }
@@ -268,24 +268,24 @@ exports[`<MenuButton /> with default options matches its snapshot 1`] = `
     Object {
       "root": Object {
         "border": 0,
-        "color": "#495361",
+        "color": "rgb(73,83,97)",
         "height": "20px",
         "opacity": 0.7,
         "padding": 0,
         "width": "20px",
       },
       "rootExpanded": Object {
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "opacity": 1,
       },
       "rootHovered": Object {
         "backgroundColor": "transparent",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "opacity": 1,
       },
       "rootPressed": Object {
         "backgroundColor": "transparent",
-        "color": "#386cbb",
+        "color": "rgb(56,108,187)",
         "opacity": 1,
       },
     }

--- a/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`<Text /> with color secondary matches its snapshot 1`] = `
   class=
       y-text
       {
-        color: #495361;
+        color: rgb(73,83,97);
         display: inline-block;
       }
 >

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -7,14 +7,14 @@ exports[`<Tooltip /> with additional className matches its snapshot 1`] = `
       "beakWidth": 8,
       "styles": Object {
         "beak": Object {
-          "backgroundColor": "#343A41",
+          "backgroundColor": "rgb(52,58,65)",
         },
         "beakCurtain": Object {
-          "backgroundColor": "#343A41",
+          "backgroundColor": "rgb(52,58,65)",
           "borderRadius": "2px",
         },
         "calloutMain": Object {
-          "backgroundColor": "#343A41",
+          "backgroundColor": "rgb(52,58,65)",
         },
         "container": Object {
           "backgroundColor": "inherit",
@@ -43,7 +43,7 @@ exports[`<Tooltip /> with additional className matches its snapshot 1`] = `
           "lineHeight": "1",
         },
         "subText": Object {
-          "color": "#ffffff",
+          "color": "rgb(255,255,255)",
           "fontSize": "1.2rem",
           "lineHeight": "1.6rem",
         },
@@ -60,14 +60,14 @@ exports[`<Tooltip /> with default options matches its snapshot 1`] = `
       "beakWidth": 8,
       "styles": Object {
         "beak": Object {
-          "backgroundColor": "#343A41",
+          "backgroundColor": "rgb(52,58,65)",
         },
         "beakCurtain": Object {
-          "backgroundColor": "#343A41",
+          "backgroundColor": "rgb(52,58,65)",
           "borderRadius": "2px",
         },
         "calloutMain": Object {
-          "backgroundColor": "#343A41",
+          "backgroundColor": "rgb(52,58,65)",
         },
         "container": Object {
           "backgroundColor": "inherit",
@@ -96,7 +96,7 @@ exports[`<Tooltip /> with default options matches its snapshot 1`] = `
           "lineHeight": "1",
         },
         "subText": Object {
-          "color": "#ffffff",
+          "color": "rgb(255,255,255)",
           "fontSize": "1.2rem",
           "lineHeight": "1.6rem",
         },
@@ -115,14 +115,14 @@ exports[`<Tooltip /> with directionalHint matches its snapshot 1`] = `
       "beakWidth": 8,
       "styles": Object {
         "beak": Object {
-          "backgroundColor": "#343A41",
+          "backgroundColor": "rgb(52,58,65)",
         },
         "beakCurtain": Object {
-          "backgroundColor": "#343A41",
+          "backgroundColor": "rgb(52,58,65)",
           "borderRadius": "2px",
         },
         "calloutMain": Object {
-          "backgroundColor": "#343A41",
+          "backgroundColor": "rgb(52,58,65)",
         },
         "container": Object {
           "backgroundColor": "inherit",
@@ -152,7 +152,7 @@ exports[`<Tooltip /> with directionalHint matches its snapshot 1`] = `
           "lineHeight": "1",
         },
         "subText": Object {
-          "color": "#ffffff",
+          "color": "rgb(255,255,255)",
           "fontSize": "1.2rem",
           "lineHeight": "1.6rem",
         },

--- a/src/util/colors.ts
+++ b/src/util/colors.ts
@@ -1,65 +1,63 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import { IPalette, ISemanticColors } from 'office-ui-fabric-react/lib/Styling';
 
-/*
-* Yammer's Color Palette - Uncomment as needed.
-*/
+const yammerColors = {
+  /* Blue */
+  blue: 'rgb(36,119,195)', // #2477c3';
+  stream: 'rgb(233,239,248)', // '#e9eff8';
+  pond: 'rgb(154,195,255)', // '#9ac3ff';
+  lake: 'rgb(108,152,217)', // '#6c98d9';
+  newBlue: 'rgb(47,92,159)', // '#2f5c9f';
+  river: 'rgb(56,108,187)', // '#386cbb';
+  bay: 'rgb(38,79,140)', // '#264f8c';
+  ocean: 'rgb(25,52,93)', // '#19345d';
 
-/* Blue */
-// const blue = '#2477c3';
-// const stream = '#e9eff8';
-const pond = '#9ac3ff';
-const lake = '#6c98d9';
-const newBlue = '#2f5c9f';
-const river = '#386cbb';
-const bay = '#264f8c';
-// const ocean = '#19345d';
+  /* Gray */
+  white: 'rgb(255,255,255)', // '#ffffff';
+  popRock: 'rgb(243,245,248)', // '#f3f5f8';
+  altRock: 'rgb(237,239,242)', // '#edeff2';
+  indieRock: 'rgb(221,224,230)', // '#dde0e6';
+  punkRock: 'rgb(168,176,189)', // '#a8b0bd';
+  heavyMetal: 'rgb(100,109,122)', // '#646d7a';
+  deathMetal: 'rgb(73,83,97)', // '#495361';
+  blackMetal: 'rgb(52,58,65)', // '#343A41';
 
-/* Gray */
-const white = '#ffffff';
-const popRock = '#f3f5f8';
-const altRock = '#edeff2';
-const indieRock = '#dde0e6';
-const punkRock = '#a8b0bd';
-const heavyMetal = '#646d7a';
-const deathMetal = '#495361';
-const blackMetal = '#343A41';
+  /* Yellow */
+  sunrise: 'rgb(255,231,184)', // '#ffe7b8';
+  noon: 'rgb(255,197,108)', // '#ffc56c';
+  sunset: 'rgb(248,174,65)', // '#f8ae41';
 
-/* Yellow */
-// const sunrise = '#ffe7b8';
-// const noon = '#ffc56c';
-// const sunset = '#f8ae41';
+  /* Red */
+  angel: 'rgb(251,127,120)', // '#fb7f78';
+  lestat: 'rgb(209,66,59)', // '#d1423b';
+  dracula: 'rgb(158,48,40)', // '#9e3028';
 
-/* Red */
-// const angel = '#fb7f78';
-const lestat = '#d1423b';
-const dracula = '#9e3028';
-
-/* Green */
-// const leaf = '#84ca4b';
-// const tree = '#338323';
-// const forest = '#27641b';
+  /* Green */
+  leaf: 'rgb(132,202,75)', // '#84ca4b';
+  tree: 'rgb(51,131,35)', // '#338323';
+  forest: 'rgb(39,100,27)', // '#27641b';
+};
 
 /*
  * Used globally by Fabric
  */
 export const palette: Partial<IPalette> = {
-  themeDarker: bay,
-  themeDark: river,
-  themeDarkAlt: newBlue,
-  themePrimary: lake,
-  themeLighter: pond,
-  neutralDark: indieRock,
-  neutralPrimary: blackMetal,
-  neutralPrimaryAlt: deathMetal,
-  neutralSecondary: heavyMetal,
-  neutralTertiary: indieRock,
-  neutralTertiaryAlt: punkRock,
-  neutralLight: altRock,
-  neutralLighter: popRock,
-  redDark: dracula,
-  red: lestat,
-  white,
+  themeDarker: yammerColors.bay,
+  themeDark: yammerColors.river,
+  themeDarkAlt: yammerColors.newBlue,
+  themePrimary: yammerColors.lake,
+  themeLighter: yammerColors.pond,
+  neutralDark: yammerColors.indieRock,
+  neutralPrimary: yammerColors.blackMetal,
+  neutralPrimaryAlt: yammerColors.deathMetal,
+  neutralSecondary: yammerColors.heavyMetal,
+  neutralTertiary: yammerColors.indieRock,
+  neutralTertiaryAlt: yammerColors.punkRock,
+  neutralLight: yammerColors.altRock,
+  neutralLighter: yammerColors.popRock,
+  redDark: yammerColors.dracula,
+  red: yammerColors.lestat,
+  white: yammerColors.white,
 };
 
 /*


### PR DESCRIPTION
This unblocks Spinner work where we need to use a Fabric util to add an alpha channel to a CSS color. `colors.ts` is the only changed file, the rest are updated snapshots