### PR TITLE
Remove design codeowners for now

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,3 @@
 # Order is important. The last matching pattern has the most precedence.
 
 * @swese44 @unindented @richardtagger
-
-config/styleguide-visual/reference/*    @vanschyndel @cainhimself @dan5382


### PR DESCRIPTION
Plan is to flush the queue of PRs before we pause
