### PR TITLE
Remove Context API - Use 'selectors' styles instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3458,12 +3458,6 @@
         "prop-types": "^15.6.0"
       }
     },
-    "enzyme-context-patch": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/enzyme-context-patch/-/enzyme-context-patch-0.0.7.tgz",
-      "integrity": "sha512-Bn86hb18yAywCh+H71fxax3xxVv5iEKXh3TKx0xzg1/j5o/S4FUStN1AZvzNuDL4lGA/uZo3o8kskBK3jL9khQ==",
-      "dev": true
-    },
     "enzyme-to-json": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "css-loader": "0.27.3",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
-    "enzyme-context-patch": "0.0.7",
     "enzyme-to-json": "3.3.3",
     "eslint": "4.19.1",
     "eslint-config-airbnb": "16.1.0",

--- a/src/components/Block/Block.styles.ts
+++ b/src/components/Block/Block.styles.ts
@@ -15,12 +15,11 @@ const getMarginTop = (topSpacing?: GutterSize, push?: number) => {
   }
 };
 
-export const getStyles = (props: BlockProps & { withinClickable: boolean }): IRawStyle => {
-  const { push, textSize, topSpacing, bottomSpacing, textAlign, textColor, withinClickable } = props;
+export const getStyles = (props: BlockProps): IRawStyle => {
+  const { push, textSize, topSpacing, bottomSpacing, textAlign, textColor } = props;
 
   return {
     textAlign,
-    width: withinClickable ? '100%' : undefined,
     color: textColor ? textColors[textColor] : undefined,
     fontSize: textSize ? fontSizes[textSize] : undefined,
     lineHeight: textSize ? lineHeights[textSize] : undefined,

--- a/src/components/Block/Block.styles.ts
+++ b/src/components/Block/Block.styles.ts
@@ -1,7 +1,7 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import { BlockProps } from './Block';
 import { GutterSize } from '../FixedGrid/types';
-import { textColors, fontSizes, lineHeights, ellipsisStyle } from '../../util/styles/fonts';
+import { textColors, fontSizes, lineHeights, ellipsisStyle, verticalAligns } from '../../util/styles/fonts';
 import { gutterSize } from '../../util/styles/gutters';
 import { IRawStyle } from '@uifabric/styling';
 
@@ -27,6 +27,11 @@ export const getStyles = (props: BlockProps): IRawStyle => {
     marginBottom: bottomSpacing ? gutterSize[bottomSpacing] : undefined,
     // For positive push, "push" it down with top padding (because margins can collapse).
     paddingTop: push && push > 0 ? `${push / 10}rem` : undefined,
+    selectors: {
+      '.y-text__ellipsis': {
+        verticalAlign: textSize ? verticalAligns[textSize] : undefined,
+      },
+    },
   };
 };
 

--- a/src/components/Block/Block.test.tsx
+++ b/src/components/Block/Block.test.tsx
@@ -1,20 +1,14 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import { create as createRenderer, ReactTestRendererJSON } from 'react-test-renderer';
-import { renderIntoDocument, findRenderedDOMComponentWithClass } from 'react-dom/test-utils';
-import Block, { GutterSize, TextColor, TextSize } from '.';
-import Clickable from '../Clickable';
-
-const render = (jsx: JSX.Element) => {
-  return createRenderer(jsx).toJSON();
-};
+import { shallow, ShallowWrapper } from 'enzyme';
+import Block, { BlockProps, GutterSize, TextColor, TextSize } from '.';
 
 describe('<Block />', () => {
-  let component: ReactTestRendererJSON | null;
+  let component: ShallowWrapper<BlockProps>;
 
   describe('with default options', () => {
     beforeEach(() => {
-      component = render(<Block>block content</Block>);
+      component = shallow(<Block>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -24,7 +18,7 @@ describe('<Block />', () => {
 
   describe('with additional className', () => {
     beforeEach(() => {
-      component = render(<Block className="TEST_CLASSNAME">block content</Block>);
+      component = shallow(<Block className="TEST_CLASSNAME">block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -34,7 +28,7 @@ describe('<Block />', () => {
 
   describe('with xLarge text size', () => {
     beforeEach(() => {
-      component = render(<Block textSize={TextSize.XLARGE}>block content</Block>);
+      component = shallow(<Block textSize={TextSize.XLARGE}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -44,7 +38,7 @@ describe('<Block />', () => {
 
   describe('with secondary textColor', () => {
     beforeEach(() => {
-      component = render(<Block textColor={TextColor.SECONDARY}>block content</Block>);
+      component = shallow(<Block textColor={TextColor.SECONDARY}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -53,30 +47,18 @@ describe('<Block />', () => {
   });
 
   describe('with textAlign', () => {
-    describe('right', () => {
-      beforeEach(() => {
-        component = render(<Block textAlign="right">block content</Block>);
-      });
-
-      it('matches its snapshot', () => {
-        expect(component).toMatchSnapshot();
-      });
+    beforeEach(() => {
+      component = shallow(<Block textAlign="right">block content</Block>);
     });
 
-    describe('center', () => {
-      beforeEach(() => {
-        component = render(<Block textAlign="center">block content</Block>);
-      });
-
-      it('matches its snapshot', () => {
-        expect(component).toMatchSnapshot();
-      });
+    it('matches its snapshot', () => {
+      expect(component).toMatchSnapshot();
     });
   });
 
   describe('with ellipsis', () => {
     beforeEach(() => {
-      component = render(<Block ellipsis={true}>block content</Block>);
+      component = shallow(<Block ellipsis={true}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -86,7 +68,7 @@ describe('<Block />', () => {
 
   describe('with top spacing', () => {
     beforeEach(() => {
-      component = render(<Block topSpacing={GutterSize.SMALL}>block content</Block>);
+      component = shallow(<Block topSpacing={GutterSize.SMALL}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -96,7 +78,7 @@ describe('<Block />', () => {
 
   describe('with bottom spacing', () => {
     beforeEach(() => {
-      component = render(<Block bottomSpacing={GutterSize.XLARGE}>block content</Block>);
+      component = shallow(<Block bottomSpacing={GutterSize.XLARGE}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -106,7 +88,7 @@ describe('<Block />', () => {
 
   describe('with padding', () => {
     beforeEach(() => {
-      component = render(<Block padding={GutterSize.SMALL}>block content</Block>);
+      component = shallow(<Block padding={GutterSize.SMALL}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -116,7 +98,7 @@ describe('<Block />', () => {
 
   describe('with horizontal padding', () => {
     beforeEach(() => {
-      component = render(<Block horizontalPadding={GutterSize.MEDIUM}>block content</Block>);
+      component = shallow(<Block horizontalPadding={GutterSize.MEDIUM}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -126,7 +108,7 @@ describe('<Block />', () => {
 
   describe('with vertical padding', () => {
     beforeEach(() => {
-      component = render(<Block verticalPadding={GutterSize.XLARGE}>block content</Block>);
+      component = shallow(<Block verticalPadding={GutterSize.XLARGE}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -136,7 +118,7 @@ describe('<Block />', () => {
 
   describe('with positive push', () => {
     beforeEach(() => {
-      component = render(<Block push={3}>block content</Block>);
+      component = shallow(<Block push={3}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
@@ -146,27 +128,11 @@ describe('<Block />', () => {
 
   describe('with negative push', () => {
     beforeEach(() => {
-      component = render(<Block push={-2}>block content</Block>);
+      component = shallow(<Block push={-2}>block content</Block>);
     });
 
     it('matches its snapshot', () => {
       expect(component).toMatchSnapshot();
-    });
-  });
-
-  describe('within clickable', () => {
-    let rendered: Clickable;
-
-    beforeEach(() => {
-      rendered = renderIntoDocument(
-        <Clickable>
-          <Block>block content</Block>
-        </Clickable>,
-      ) as Clickable;
-    });
-
-    it('matches its snapshot', () => {
-      expect(findRenderedDOMComponentWithClass(rendered, 'y-block')).toMatchSnapshot();
     });
   });
 });

--- a/src/components/Block/Block.tsx
+++ b/src/components/Block/Block.tsx
@@ -63,14 +63,6 @@ export interface BlockProps extends NestableBaseComponentProps {
   ellipsis?: boolean;
 }
 
-export interface BlockContext {
-  textSize?: TextSize;
-}
-
-const defaultContext: BlockContext = {};
-
-export const BlockContext = React.createContext(defaultContext);
-
 /**
  * A `Block` is a layout component to build consistent padding and vertical spacing between
  * components. It allows you to `push` a chunk of UI up or down by individual pixels to keep text in
@@ -79,14 +71,12 @@ export const BlockContext = React.createContext(defaultContext);
  */
 export default class Block extends React.Component<BlockProps> {
   public render() {
-    const { children, textSize } = this.props;
+    const { children } = this.props;
 
     return (
-      <BlockContext.Provider value={{ textSize }}>
-        <div className={this.getClasses()}>
-          <div className={`y-block--inner ${mergeStyles(getInnerStyles(this.props))}`}>{children}</div>
-        </div>
-      </BlockContext.Provider>
+      <div className={this.getClasses()}>
+        <div className={`y-block--inner ${mergeStyles(getInnerStyles(this.props))}`}>{children}</div>
+      </div>
     );
   }
 

--- a/src/components/Block/Block.tsx
+++ b/src/components/Block/Block.tsx
@@ -3,7 +3,6 @@ import '../../yamui';
 import * as React from 'react';
 import { join } from '../../util/classNames';
 import { NestableBaseComponentProps } from '../../util/BaseComponent/props';
-import { ClickableContext } from '../Clickable';
 import { GutterSize } from '../FixedGrid/types';
 import { TextColor, TextSize } from '../Text/types';
 import { getStyles, getInnerStyles } from './Block.styles';
@@ -83,25 +82,16 @@ export default class Block extends React.Component<BlockProps> {
     const { children, textSize } = this.props;
 
     return (
-      <ClickableContext.Consumer>
-        {clickableContext => (
-          <BlockContext.Provider value={{ textSize }}>
-            <div className={this.getClasses(clickableContext.withinClickable)}>
-              <div className={`y-block--inner ${mergeStyles(getInnerStyles(this.props))}`}>{children}</div>
-            </div>
-          </BlockContext.Provider>
-        )}
-      </ClickableContext.Consumer>
+      <BlockContext.Provider value={{ textSize }}>
+        <div className={this.getClasses()}>
+          <div className={`y-block--inner ${mergeStyles(getInnerStyles(this.props))}`}>{children}</div>
+        </div>
+      </BlockContext.Provider>
     );
   }
 
-  private getClasses(withinClickable: boolean) {
+  private getClasses() {
     const { className, textSize } = this.props;
-    return join([
-      'y-block',
-      textSize ? `y-textSize-${textSize}` : '',
-      className,
-      mergeStyles(getStyles({ ...this.props, withinClickable })),
-    ]);
+    return join(['y-block', textSize ? `y-textSize-${textSize}` : '', className, mergeStyles(getStyles(this.props))]);
   }
 }

--- a/src/components/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/components/Block/__snapshots__/Block.test.tsx.snap
@@ -178,28 +178,7 @@ exports[`<Block /> with secondary textColor matches its snapshot 1`] = `
 </div>
 `;
 
-exports[`<Block /> with textAlign center matches its snapshot 1`] = `
-<div
-  className=
-      y-block
-      {
-        text-align: center;
-      }
->
-  <div
-    className=
-        y-block--inner
-        {
-          overflow-wrap: break-word;
-          word-wrap: break-word;
-        }
-  >
-    block content
-  </div>
-</div>
-`;
-
-exports[`<Block /> with textAlign right matches its snapshot 1`] = `
+exports[`<Block /> with textAlign matches its snapshot 1`] = `
 <div
   className=
       y-block
@@ -275,23 +254,6 @@ exports[`<Block /> with xLarge text size matches its snapshot 1`] = `
 >
   <div
     className=
-        y-block--inner
-        {
-          overflow-wrap: break-word;
-          word-wrap: break-word;
-        }
-  >
-    block content
-  </div>
-</div>
-`;
-
-exports[`<Block /> within clickable matches its snapshot 1`] = `
-<div
-  class="y-block"
->
-  <div
-    class=
         y-block--inner
         {
           overflow-wrap: break-word;

--- a/src/components/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/components/Block/__snapshots__/Block.test.tsx.snap
@@ -269,6 +269,9 @@ exports[`<Block /> with xLarge text size matches its snapshot 1`] = `
         font-size: 2.2rem;
         line-height: 2.8rem;
       }
+      & .y-text__ellipsis {
+        vertical-align: -0.5rem;
+      }
 >
   <div
     className=

--- a/src/components/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/components/Block/__snapshots__/Block.test.tsx.snap
@@ -285,11 +285,7 @@ exports[`<Block /> with xLarge text size matches its snapshot 1`] = `
 
 exports[`<Block /> within clickable matches its snapshot 1`] = `
 <div
-  class=
-      y-block
-      {
-        width: 100%;
-      }
+  class="y-block"
 >
   <div
     class=

--- a/src/components/Clickable/Clickable.styles.ts
+++ b/src/components/Clickable/Clickable.styles.ts
@@ -24,7 +24,7 @@ export const getClassNames = memoizeFunction((styleProps: ClickableStyleProps) =
       display: block ? 'block' : 'inline',
       width: block ? '100%' : 'undefined',
       selectors: {
-        '.y-block': {
+        '> .y-block': {
           width: '100%',
         },
       },

--- a/src/components/Clickable/Clickable.styles.ts
+++ b/src/components/Clickable/Clickable.styles.ts
@@ -23,6 +23,11 @@ export const getClassNames = memoizeFunction((styleProps: ClickableStyleProps) =
       cursor: 'pointer',
       display: block ? 'block' : 'inline',
       width: block ? '100%' : 'undefined',
+      selectors: {
+        '.y-block': {
+          width: '100%',
+        },
+      },
     },
   });
 });

--- a/src/components/Clickable/Clickable.tsx
+++ b/src/components/Clickable/Clickable.tsx
@@ -33,14 +33,6 @@ export interface ClickableProps extends NestableBaseComponentProps, FocusableCom
   onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void);
 }
 
-export interface ClickableContext {
-  withinClickable: boolean;
-}
-
-const defaultContext: ClickableContext = { withinClickable: false };
-
-export const ClickableContext = React.createContext(defaultContext);
-
 /**
  * A `Clickable` is an accessible, clickable area that accepts arbitrary children. It is styled
  * like a link by default, but can also be unstyled. Under the hood `Clickable` simply wraps
@@ -61,18 +53,16 @@ export default class Clickable extends React.Component<ClickableProps> {
     const classNames = getClassNames({ block });
 
     return (
-      <ClickableContext.Provider value={{ withinClickable: true }}>
-        <button
-          className={join(['y-clickable', classNames.root, className])}
-          aria-label={ariaLabel}
-          title={title}
-          onClick={onClick}
-          type="button"
-          ref={this.buttonRef}
-        >
-          {unstyled ? children : <FakeLink>{children}</FakeLink>}
-        </button>
-      </ClickableContext.Provider>
+      <button
+        className={join(['y-clickable', classNames.root, className])}
+        aria-label={ariaLabel}
+        title={title}
+        onClick={onClick}
+        type="button"
+        ref={this.buttonRef}
+      >
+        {unstyled ? children : <FakeLink>{children}</FakeLink>}
+      </button>
     );
   }
 

--- a/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
+++ b/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
@@ -25,6 +25,9 @@ exports[`<Clickable /> when ariaLabel is passed matches its snapshot 1`] = `
         text-align: inherit;
         width: undefined;
       }
+      & .y-block {
+        width: 100%;
+      }
   type="button"
 >
   <span
@@ -57,6 +60,9 @@ exports[`<Clickable /> when block is true matches its snapshot 1`] = `
         padding-right: 0px;
         padding-top: 0px;
         text-align: inherit;
+        width: 100%;
+      }
+      & .y-block {
         width: 100%;
       }
   type="button"
@@ -93,6 +99,9 @@ exports[`<Clickable /> when focusableRef is passed matches its snapshot 1`] = `
         text-align: inherit;
         width: undefined;
       }
+      & .y-block {
+        width: 100%;
+      }
   type="button"
 >
   <span
@@ -126,6 +135,9 @@ exports[`<Clickable /> when title is passed matches its snapshot 1`] = `
         padding-top: 0px;
         text-align: inherit;
         width: undefined;
+      }
+      & .y-block {
+        width: 100%;
       }
   title="extra browser tooltip content"
   type="button"
@@ -162,6 +174,9 @@ exports[`<Clickable /> when unstyled matches its snapshot 1`] = `
         text-align: inherit;
         width: undefined;
       }
+      & .y-block {
+        width: 100%;
+      }
   type="button"
 >
   clickable content
@@ -192,6 +207,9 @@ exports[`<Clickable /> with additional className matches its snapshot 1`] = `
         padding-top: 0px;
         text-align: inherit;
         width: undefined;
+      }
+      & .y-block {
+        width: 100%;
       }
   type="button"
 >
@@ -226,6 +244,9 @@ exports[`<Clickable /> with default options matches its snapshot 1`] = `
         padding-top: 0px;
         text-align: inherit;
         width: undefined;
+      }
+      & .y-block {
+        width: 100%;
       }
   type="button"
 >

--- a/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
+++ b/src/components/Clickable/__snapshots__/Clickable.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<Clickable /> when ariaLabel is passed matches its snapshot 1`] = `
         text-align: inherit;
         width: undefined;
       }
-      & .y-block {
+      & > .y-block {
         width: 100%;
       }
   type="button"
@@ -62,7 +62,7 @@ exports[`<Clickable /> when block is true matches its snapshot 1`] = `
         text-align: inherit;
         width: 100%;
       }
-      & .y-block {
+      & > .y-block {
         width: 100%;
       }
   type="button"
@@ -99,7 +99,7 @@ exports[`<Clickable /> when focusableRef is passed matches its snapshot 1`] = `
         text-align: inherit;
         width: undefined;
       }
-      & .y-block {
+      & > .y-block {
         width: 100%;
       }
   type="button"
@@ -136,7 +136,7 @@ exports[`<Clickable /> when title is passed matches its snapshot 1`] = `
         text-align: inherit;
         width: undefined;
       }
-      & .y-block {
+      & > .y-block {
         width: 100%;
       }
   title="extra browser tooltip content"
@@ -174,7 +174,7 @@ exports[`<Clickable /> when unstyled matches its snapshot 1`] = `
         text-align: inherit;
         width: undefined;
       }
-      & .y-block {
+      & > .y-block {
         width: 100%;
       }
   type="button"
@@ -208,7 +208,7 @@ exports[`<Clickable /> with additional className matches its snapshot 1`] = `
         text-align: inherit;
         width: undefined;
       }
-      & .y-block {
+      & > .y-block {
         width: 100%;
       }
   type="button"
@@ -245,7 +245,7 @@ exports[`<Clickable /> with default options matches its snapshot 1`] = `
         text-align: inherit;
         width: undefined;
       }
-      & .y-block {
+      & > .y-block {
         width: 100%;
       }
   type="button"

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -10,6 +10,9 @@ exports[`<Dropdown /> option templates with icon matches its snapshot 1`] = `
         font-size: 1.4rem;
         line-height: 2.0rem;
       }
+      & .y-text__ellipsis {
+        vertical-align: -0.5rem;
+      }
 >
   <div
     className=
@@ -109,6 +112,9 @@ exports[`<Dropdown /> option templates with label matches its snapshot 1`] = `
       {
         font-size: 1.4rem;
         line-height: 2.0rem;
+      }
+      & .y-text__ellipsis {
+        vertical-align: -0.5rem;
       }
 >
   <div
@@ -262,6 +268,9 @@ exports[`<Dropdown /> with section header matches its snapshot 1`] = `
       {
         font-size: 1.2rem;
         line-height: 1.6rem;
+      }
+      & .y-text__ellipsis {
+        vertical-align: -0.3rem;
       }
 >
   <div

--- a/src/components/Text/Text.styles.ts
+++ b/src/components/Text/Text.styles.ts
@@ -14,12 +14,8 @@ const getHeight = (size?: TextSize) => {
   return size ? lineHeights[size] : undefined;
 };
 
-const getVerticalAlignForMaxWidth = (size?: TextSize) => {
-  return size ? verticalAligns[size] : '-0.4rem';
-};
-
-export const getStyles = (props: TextProps & { blockTextSize?: TextSize }): IRawStyle => {
-  const { size, maxWidth, bold, uppercase, color, blockTextSize } = props;
+export const getStyles = (props: TextProps): IRawStyle => {
+  const { size, maxWidth, bold, uppercase, color } = props;
 
   return {
     ...(maxWidth ? ellipsisStyle : {}),
@@ -31,6 +27,12 @@ export const getStyles = (props: TextProps & { blockTextSize?: TextSize }): IRaw
     color: color ? textColors[color] : undefined,
     maxWidth: maxWidth || undefined,
     height: maxWidth ? getHeight(size) : undefined,
-    verticalAlign: maxWidth ? getVerticalAlignForMaxWidth(size || blockTextSize) : undefined,
+    verticalAlign: maxWidth ? '-0.4rem' : undefined,
+    selectors: {
+      /* increased specificity to override the block style */
+      '&.y-text.y-text__ellipsis': {
+        verticalAlign: maxWidth && size ? verticalAligns[size] : undefined,
+      },
+    },
   };
 };

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -1,19 +1,15 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import { renderIntoDocument, findRenderedDOMComponentWithClass } from 'react-dom/test-utils';
-import Text, { TextColor, TextSize } from '.';
+import { shallow, ShallowWrapper } from 'enzyme';
 
-const render = (jsx: JSX.Element) => {
-  const renderedText = renderIntoDocument(jsx) as Text;
-  return findRenderedDOMComponentWithClass(renderedText, 'y-text');
-};
+import Text, { TextProps, TextColor, TextSize } from '.';
 
 describe('<Text />', () => {
-  let component: Element;
+  let component: ShallowWrapper<TextProps>;
 
   describe('with default options', () => {
     beforeEach(() => {
-      component = render(<Text>test content</Text>);
+      component = shallow(<Text>test content</Text>);
     });
 
     it('matches its snapshot', () => {
@@ -23,7 +19,7 @@ describe('<Text />', () => {
 
   describe('with additional className', () => {
     beforeEach(() => {
-      component = render(<Text className="TEST_CLASSNAME">test content</Text>);
+      component = shallow(<Text className="TEST_CLASSNAME">test content</Text>);
     });
 
     it('matches its snapshot', () => {
@@ -33,21 +29,7 @@ describe('<Text />', () => {
 
   describe('with a valid size', () => {
     beforeEach(() => {
-      component = render(<Text size={TextSize.XLARGE}>test content</Text>);
-    });
-
-    it('matches its snapshot', () => {
-      expect(component).toMatchSnapshot();
-    });
-  });
-
-  describe('with a valid size and maxWidth', () => {
-    beforeEach(() => {
-      component = render(
-        <Text size={TextSize.XLARGE} maxWidth="200px">
-          test content
-        </Text>,
-      );
+      component = shallow(<Text size={TextSize.XLARGE}>test content</Text>);
     });
 
     it('matches its snapshot', () => {
@@ -57,7 +39,7 @@ describe('<Text />', () => {
 
   describe('with bold', () => {
     beforeEach(() => {
-      component = render(<Text bold={true}>test content</Text>);
+      component = shallow(<Text bold={true}>test content</Text>);
     });
 
     it('matches its snapshot', () => {
@@ -67,7 +49,7 @@ describe('<Text />', () => {
 
   describe('with uppercase', () => {
     beforeEach(() => {
-      component = render(<Text uppercase={true}>test content</Text>);
+      component = shallow(<Text uppercase={true}>test content</Text>);
     });
 
     it('matches its snapshot', () => {
@@ -77,7 +59,7 @@ describe('<Text />', () => {
 
   describe('with maxWidth 500px', () => {
     beforeEach(() => {
-      component = render(<Text maxWidth="500px">test content</Text>);
+      component = shallow(<Text maxWidth="500px">test content</Text>);
     });
 
     it('matches its snapshot', () => {
@@ -87,7 +69,7 @@ describe('<Text />', () => {
 
   describe('with color secondary', () => {
     beforeEach(() => {
-      component = render(<Text color={TextColor.SECONDARY}>test content</Text>);
+      component = shallow(<Text color={TextColor.SECONDARY}>test content</Text>);
     });
 
     it('matches its snapshot', () => {
@@ -97,7 +79,7 @@ describe('<Text />', () => {
 
   describe('with screenreader text', () => {
     beforeEach(() => {
-      component = render(<Text screenreaderText="SCREENREADER TEXT">test content</Text>);
+      component = shallow(<Text screenreaderText="SCREENREADER TEXT">test content</Text>);
     });
 
     it('matches its snapshot', () => {
@@ -107,7 +89,7 @@ describe('<Text />', () => {
 
   describe('with screenreader text empty string', () => {
     beforeEach(() => {
-      component = render(<Text screenreaderText="">test content</Text>);
+      component = shallow(<Text screenreaderText="">test content</Text>);
     });
 
     it('matches its snapshot', () => {

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -2,7 +2,6 @@
 import '../../yamui';
 import * as React from 'react';
 import { join } from '../../util/classNames';
-import { BlockContext } from '../Block';
 import { NestableBaseComponentProps } from '../../util/BaseComponent/props';
 import { TextColor, TextSize } from './types';
 import ScreenReaderText from '../ScreenreaderText';
@@ -53,12 +52,8 @@ export interface TextProps extends NestableBaseComponentProps {
  */
 export default class Text extends React.Component<TextProps> {
   public render() {
-    return <BlockContext.Consumer>{blockContext => this.getContent(blockContext.textSize)}</BlockContext.Consumer>;
-  }
-
-  private getContent(blockTextSize?: TextSize) {
     const { children, screenreaderText } = this.props;
-    const classes = this.getClasses(blockTextSize);
+    const classes = this.getClasses();
 
     if (screenreaderText !== undefined) {
       return (
@@ -71,14 +66,14 @@ export default class Text extends React.Component<TextProps> {
     return <span className={classes}>{children}</span>;
   }
 
-  private getClasses(blockTextSize?: TextSize) {
+  private getClasses() {
     const { className, size, maxWidth } = this.props;
     return join([
       'y-text',
       size ? `y-textSize-${size}` : '',
       maxWidth ? 'y-text__ellipsis' : '',
       className,
-      mergeStyles(getStyles({ ...this.props, blockTextSize })),
+      mergeStyles(getStyles(this.props)),
     ]);
   }
 }

--- a/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -1,33 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Text /> with a valid size and maxWidth matches its snapshot 1`] = `
-<span
-  class=
-      y-text
-      y-textSize-xLarge
-      y-text__ellipsis
-      {
-        display: inline-block;
-        font-size: 2.2rem;
-        height: 2.8rem;
-        line-height: 2.8rem;
-        max-width: 200px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        vertical-align: -0.4rem;
-        white-space: nowrap;
-      }
-      &.y-text.y-text__ellipsis {
-        vertical-align: -0.5rem;
-      }
->
-  test content
-</span>
-`;
-
 exports[`<Text /> with a valid size matches its snapshot 1`] = `
 <span
-  class=
+  className=
       y-text
       y-textSize-xLarge
       {
@@ -42,7 +17,7 @@ exports[`<Text /> with a valid size matches its snapshot 1`] = `
 
 exports[`<Text /> with additional className matches its snapshot 1`] = `
 <span
-  class=
+  className=
       y-text
       TEST_CLASSNAME
       {
@@ -55,7 +30,7 @@ exports[`<Text /> with additional className matches its snapshot 1`] = `
 
 exports[`<Text /> with bold matches its snapshot 1`] = `
 <span
-  class=
+  className=
       y-text
       {
         display: inline-block;
@@ -68,7 +43,7 @@ exports[`<Text /> with bold matches its snapshot 1`] = `
 
 exports[`<Text /> with color secondary matches its snapshot 1`] = `
 <span
-  class=
+  className=
       y-text
       {
         color: #495361;
@@ -81,7 +56,7 @@ exports[`<Text /> with color secondary matches its snapshot 1`] = `
 
 exports[`<Text /> with default options matches its snapshot 1`] = `
 <span
-  class=
+  className=
       y-text
       {
         display: inline-block;
@@ -93,7 +68,7 @@ exports[`<Text /> with default options matches its snapshot 1`] = `
 
 exports[`<Text /> with maxWidth 500px matches its snapshot 1`] = `
 <span
-  class=
+  className=
       y-text
       y-text__ellipsis
       {
@@ -111,49 +86,43 @@ exports[`<Text /> with maxWidth 500px matches its snapshot 1`] = `
 
 exports[`<Text /> with screenreader text empty string matches its snapshot 1`] = `
 <span
-  class=
+  className=
       y-text
       {
         display: inline-block;
       }
 >
   <span
-    aria-hidden="true"
+    aria-hidden={true}
   >
     test content
   </span>
-  <span
-    class="y-screenreaderText"
-    style="display: block; padding: 0px; border: 0px; position: absolute; margin: -1px; height: 1px; width: 1px; overflow: hidden; word-wrap: normal;"
-  />
+  <ScreenreaderText />
 </span>
 `;
 
 exports[`<Text /> with screenreader text matches its snapshot 1`] = `
 <span
-  class=
+  className=
       y-text
       {
         display: inline-block;
       }
 >
   <span
-    aria-hidden="true"
+    aria-hidden={true}
   >
     test content
   </span>
-  <span
-    class="y-screenreaderText"
-    style="display: block; padding: 0px; border: 0px; position: absolute; margin: -1px; height: 1px; width: 1px; overflow: hidden; word-wrap: normal;"
-  >
+  <ScreenreaderText>
     SCREENREADER TEXT
-  </span>
+  </ScreenreaderText>
 </span>
 `;
 
 exports[`<Text /> with uppercase matches its snapshot 1`] = `
 <span
-  class=
+  className=
       y-text
       {
         display: inline-block;

--- a/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -14,8 +14,11 @@ exports[`<Text /> with a valid size and maxWidth matches its snapshot 1`] = `
         max-width: 200px;
         overflow: hidden;
         text-overflow: ellipsis;
-        vertical-align: -0.5rem;
+        vertical-align: -0.4rem;
         white-space: nowrap;
+      }
+      &.y-text.y-text__ellipsis {
+        vertical-align: -0.5rem;
       }
 >
   test content


### PR DESCRIPTION
The use of the context api here was causing test failures in downstream dependencies, since it is not yet fully supported by enzyme. 

We were using context to achieve styles that were dependent on a specific nesting of components. 

Instead, we can use the `selectors` facility offered by merge-styles to achieve is, which I think is an overall better solution anyway.

fixes #411 