### PR TITLE
feat(resize observer): introduce polyfill

### DIFF
--- a/config/styleguide/webpack.config.js
+++ b/config/styleguide/webpack.config.js
@@ -17,6 +17,15 @@ module.exports = {
           transpileOnly: true,
         },
       },
+      {
+        test: require.resolve('resize-observer-polyfill'),
+        use: [
+          {
+            loader: 'expose-loader',
+            options: 'ResizeObserver',
+          },
+        ],
+      },
     ],
   },
   resolve: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15548,6 +15548,11 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz",
+      "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
+    },
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-styleguidist": "7.0.14",
     "react-styleguidist-visual": "0.8.0",
     "react-test-renderer": "16.3.2",
+    "resize-observer-polyfill": "1.5.0",
     "rimraf": "2.6.1",
     "style-loader": "0.16.1",
     "svgo": "1.0.3",


### PR DESCRIPTION
Adds a polyfill for resize observer, which will be used in upcoming YamUI components (GridList and
ContainerQuery).

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [x] Component is unit tested.
