### PR TITLE
use strings from palette as backgroundColor

### DIFF
--- a/src/components/Block/Block.md
+++ b/src/components/Block/Block.md
@@ -214,7 +214,7 @@ const { GutterSize, TextColor } = require('.');
   <Block textColor={TextColor.METADATA} bottomSpacing={GutterSize.MEDIUM}>
     This example has <strong>textColor: METADATA</strong>.
   </Block>
-  <Block textColor={TextColor.WHITE} backgroundColor="#a8b0bd" verticalPadding={GutterSize.LARGE} horizontalPadding={GutterSize.LARGE}>
+  <Block textColor={TextColor.WHITE} backgroundColor="neutralTertiaryAlt" verticalPadding={GutterSize.LARGE} horizontalPadding={GutterSize.LARGE}>
     This example has <strong>textColor: WHITE</strong>. It should be used where the background is a darker color.
   </Block>
 </div>

--- a/src/components/Block/Block.styles.ts
+++ b/src/components/Block/Block.styles.ts
@@ -1,5 +1,5 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
-import { TextSize, TextColor } from './Block.types';
+import { TextSize, TextColor, BackgroundColor } from './Block.types';
 import { GutterSize } from '../FixedGrid/types';
 import { textColors, ellipsisStyle, verticalAligns } from '../../util/styles/fonts';
 import { gutterSize } from '../../util/styles/gutters';
@@ -25,7 +25,7 @@ export interface BlockClassNameProps {
   push?: number;
   textAlign?: 'left' | 'right' | 'center';
   textColor?: TextColor;
-  backgroundColor?: string;
+  backgroundColor?: BackgroundColor;
   textSize?: TextSize;
   ellipsis?: boolean;
 }
@@ -50,7 +50,7 @@ export const getClassNames = memoizeFunction((props: BlockClassNameProps) => {
   return mergeStyleSets({
     root: {
       textAlign,
-      backgroundColor,
+      backgroundColor: backgroundColor ? theme.palette[backgroundColor] : undefined,
       color: textColor ? textColors(theme)[textColor] : undefined,
       fontSize: font ? font.fontSize : undefined,
       lineHeight: font ? font.lineHeight : undefined,

--- a/src/components/Block/Block.test.tsx
+++ b/src/components/Block/Block.test.tsx
@@ -48,6 +48,16 @@ describe('<Block />', () => {
     });
   });
 
+  describe('with backgroundColor', () => {
+    beforeEach(() => {
+      component = shallow(<Block backgroundColor="themePrimary">block content</Block>);
+    });
+
+    it('matches its snapshot', () => {
+      expect(component).toMatchSnapshot();
+    });
+  });
+
   describe('with textAlign', () => {
     beforeEach(() => {
       component = shallow(<Block textAlign="right">block content</Block>);

--- a/src/components/Block/Block.types.ts
+++ b/src/components/Block/Block.types.ts
@@ -2,8 +2,11 @@
 import { NestableBaseComponentProps } from '../../util/BaseComponent/props';
 import { GutterSize } from '../FixedGrid/types';
 import { TextColor, TextSize } from '../Text/Text.types';
+import { IPalette } from 'office-ui-fabric-react/lib/Styling';
 
 export { GutterSize, TextColor, TextSize };
+
+export type BackgroundColor = keyof IPalette;
 
 export interface BlockProps extends NestableBaseComponentProps {
   /**
@@ -55,7 +58,7 @@ export interface BlockProps extends NestableBaseComponentProps {
   /**
    * Background color of the block.
    */
-  backgroundColor?: string;
+  backgroundColor?: BackgroundColor;
 
   /**
    * Limits text content to a single line, hiding additional text with an ellipsis.

--- a/src/components/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/components/Block/__snapshots__/Block.test.tsx.snap
@@ -20,6 +20,27 @@ exports[`<Block /> with additional className matches its snapshot 1`] = `
 </div>
 `;
 
+exports[`<Block /> with backgroundColor matches its snapshot 1`] = `
+<div
+  className=
+      y-block
+      {
+        background-color: #6c98d9;
+      }
+>
+  <div
+    className=
+        y-block--inner
+        {
+          overflow-wrap: break-word;
+          word-wrap: break-word;
+        }
+  >
+    block content
+  </div>
+</div>
+`;
+
 exports[`<Block /> with bottom spacing matches its snapshot 1`] = `
 <div
   className=

--- a/src/components/Box/Box.md
+++ b/src/components/Box/Box.md
@@ -15,5 +15,5 @@ With onClick:
 Background color:
 
 ```js { "props": { "data-description": "background color" } }
-<Box backgroundColor="#a8b0bd">This is a Box</Box>
+<Box backgroundColor="neutralTertiaryAlt">This is a Box</Box>
 ```

--- a/src/components/Box/Box.types.ts
+++ b/src/components/Box/Box.types.ts
@@ -1,5 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import { NestableBaseComponentProps } from '../../util/BaseComponent/props';
+import { BackgroundColor } from '../Block';
 
 export interface BoxProps extends NestableBaseComponentProps {
   /**
@@ -10,5 +11,5 @@ export interface BoxProps extends NestableBaseComponentProps {
   /**
    * Background color of the box.
    */
-  backgroundColor?: string;
+  backgroundColor?: BackgroundColor;
 }


### PR DESCRIPTION
This will make it easier to set the color from the consumer, since they will only need the name of the palette color, as opposed to having to consume the theme to get the color value.
