### PR TITLE
fix(a11y): use provided labelId in custom ChoiceGroup label

### DIFF
--- a/src/components/ChoiceGroup/ChoiceGroup.test.tsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.test.tsx
@@ -47,7 +47,7 @@ describe('<ChoiceGroup />', () => {
 
     it('sublabel renders as expected', () => {
       const onRenderLabel = firstOption.onRenderLabel;
-      labelWithSublabel = (onRenderLabel as Function)();
+      labelWithSublabel = (onRenderLabel as Function)({ labelId: 'label-for-aria' });
       expect(labelWithSublabel).toMatchSnapshot();
     });
 

--- a/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -10,10 +10,10 @@ import { ChoiceGroupOption, ChoiceGroupProps } from './ChoiceGroup.types';
 
 const getTextWithLabel = (text: string, label?: string) => {
   const labelContent = label ? <Text bold={true}>{label}: </Text> : null;
-  return () => (
-    <React.Fragment>
+  return ({ labelId }: { labelId?: string }) => (
+    <span id={labelId}>
       {labelContent} {text}
-    </React.Fragment>
+    </span>
   );
 };
 

--- a/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -79,7 +79,9 @@ Object {
 `;
 
 exports[`<ChoiceGroup /> with minimal props sublabel renders as expected 1`] = `
-<React.Fragment>
+<span
+  id="label-for-aria"
+>
   <CustomizedText
     bold={true}
   >
@@ -88,7 +90,7 @@ exports[`<ChoiceGroup /> with minimal props sublabel renders as expected 1`] = `
   </CustomizedText>
    
   Option A
-</React.Fragment>
+</span>
 `;
 
 exports[`<ChoiceGroup /> with minimal props when a change is triggered with an option renders as expected 1`] = `


### PR DESCRIPTION
Fabric's ChoiceGroupOption is passed a labelId that it expects
the label to use around the content. We weren't aware of or using this,
so ended up with an overall ChoiceGroupOption that had an aria-label
property on the INPUT field that didn't end up pointing to any valid
element.

This change picks up and uses the labelId to fix this.

*Describe the change you are making*

## Pull request checklist

* [X] Component `README.md` file is up-to-date.
* [X] Component is unit tested.
