### PR TITLE
fix link styles

### DIFF
--- a/src/components/NavigationLink/NavigationLink.styles.ts
+++ b/src/components/NavigationLink/NavigationLink.styles.ts
@@ -12,7 +12,11 @@ export const getClassNames = memoizeFunction((styleProps: NavigationLinkStylePro
   const { unstyled, block, theme } = styleProps;
 
   const overrides = unstyled
-    ? {}
+    ? {
+        textDecoration: 'none',
+        cursor: 'pointer',
+        color: 'inherit',
+      }
     : {
         textDecoration: 'underline',
         cursor: 'pointer',

--- a/src/components/NavigationLink/__snapshots__/NavigationLink.test.tsx.snap
+++ b/src/components/NavigationLink/__snapshots__/NavigationLink.test.tsx.snap
@@ -36,6 +36,16 @@ exports[`<NavigationLink /> when unstyled matches its snapshot 1`] = `
         cursor: pointer;
         text-decoration: none;
       }
+      &:active, &:focus, &:hover {
+        color: inherit;
+        cursor: pointer;
+        text-decoration: none;
+      }
+      &:active .y-fakeLink, &:focus .y-fakeLink, &:hover .y-fakeLink {
+        color: inherit;
+        cursor: pointer;
+        text-decoration: none;
+      }
   href="test.html"
 >
   link content

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -145,6 +145,21 @@ input[type='checkbox'] {
   margin: 0 4px 0 0;
 }
 
+/* Links */
+a {
+  color: $linkColor;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+  cursor: pointer;
+}
+a:active,
+a:focus,
+a:hover {
+  color: $linkColor__active;
+}
+
 /* Use @dark-gray for placeholder text for 4.5:1 contrast ratio. */
 /* Specify opacity to override semi-transparent placeholder text on firefox */
 input::placeholder,


### PR DESCRIPTION
This reverts some of the change that I made in https://github.com/Microsoft/YamUI/pull/489

I learned that we depend on the anchor styling for the NavigationLink component in modern client.