### PR TITLE
docs(readme): Fixing the asset instruction link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ It's best to have at least 30GB of free space for Docker containers and images. 
 
 ### Adding icons
 
-* Prepare source SVG and React SVG following [these instructions](https://github.com/Microsoft/YamUI/tree/master/assets/icons).
+* Prepare source SVG and React SVG following [these instructions](https://github.com/Microsoft/YamUI/tree/master/assets/icons/README.md).
 
 ## Releasing a new version
 


### PR DESCRIPTION
It was previously linking to the assets/icons directory instead of
linking to the README.md within that directory. This has been fixed.
