### PR TITLE
chore(styles): Scope global box-sizing rules to AppContainer and Layer components

### DIFF
--- a/src/components/AppContainer/AppContainer.styles.ts
+++ b/src/components/AppContainer/AppContainer.styles.ts
@@ -1,24 +1,39 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
-import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { mergeStyleSets, IStyle } from 'office-ui-fabric-react/lib/Styling';
 import { memoizeFunction } from 'office-ui-fabric-react/lib/Utilities';
 
+const boxSizingStyles: IStyle = {
+  boxSizing: 'border-box',
+  selectors: {
+    '*, *::before, *::after': {
+      boxSizing: 'inherit',
+    },
+  },
+};
+
 export const getClassNames = memoizeFunction(() => {
-  return mergeStyleSets({
-    root: {
-      selectors: {
-        ':global(html)': {
-          /* Sets 1.0rem to 10px */
-          fontSize: '62.5%',
-          boxSizing: 'border-box',
-        },
-        ':global(html, body)': {
-          margin: 0,
-          padding: 0,
-        },
-        ':global(*, *::before, *::after)': {
-          boxSizing: 'inherit',
+  return mergeStyleSets(
+    {
+      root: boxSizingStyles,
+    },
+    {
+      root: {
+        selectors: {
+          ':global(html)': {
+            /* Sets 1.0rem to 10px */
+            fontSize: '62.5%',
+          },
+          ':global(html, body)': {
+            margin: 0,
+            padding: 0,
+          },
         },
       },
     },
-  });
+  );
 });
+
+export const scopedSettings = {
+  CalloutContent: { styles: { calloutMain: boxSizingStyles } },
+  Modal: { styles: { root: boxSizingStyles } },
+};

--- a/src/components/AppContainer/AppContainer.tsx
+++ b/src/components/AppContainer/AppContainer.tsx
@@ -5,7 +5,7 @@ import { join } from '../../util/classNames';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import Customizer, { CustomizableComponentProps, defaultTheme } from '../Customizer';
 import { NestableBaseComponentProps } from '../../util/BaseComponent/props';
-import { getClassNames } from './AppContainer.styles';
+import { getClassNames, scopedSettings } from './AppContainer.styles';
 
 /**
  * AppContainer sets some baseline visual and accessibility styling.
@@ -16,7 +16,7 @@ export default class AppContainer extends React.Component<NestableBaseComponentP
     const classNames = getClassNames();
     return (
       <Fabric theme={theme}>
-        <Customizer settings={{ theme }}>
+        <Customizer settings={{ theme }} scopedSettings={scopedSettings}>
           <div className={join(['y-appContainer', classNames.root, className])}>{children}</div>
         </Customizer>
       </Fabric>

--- a/src/components/AppContainer/__snapshots__/AppContainer.test.tsx.snap
+++ b/src/components/AppContainer/__snapshots__/AppContainer.test.tsx.snap
@@ -308,6 +308,34 @@ exports[`<AppContainer /> with className matches its snapshot 1`] = `
   }
 >
   <Customizer
+    scopedSettings={
+      Object {
+        "CalloutContent": Object {
+          "styles": Object {
+            "calloutMain": Object {
+              "boxSizing": "border-box",
+              "selectors": Object {
+                "*, *::before, *::after": Object {
+                  "boxSizing": "inherit",
+                },
+              },
+            },
+          },
+        },
+        "Modal": Object {
+          "styles": Object {
+            "root": Object {
+              "boxSizing": "border-box",
+              "selectors": Object {
+                "*, *::before, *::after": Object {
+                  "boxSizing": "inherit",
+                },
+              },
+            },
+          },
+        },
+      }
+    }
     settings={
       Object {
         "theme": Object {
@@ -619,8 +647,13 @@ exports[`<AppContainer /> with className matches its snapshot 1`] = `
       className=
           y-appContainer
           TEST_CLASSNAME
-          html {
+          {
             box-sizing: border-box;
+          }
+          & *, *::before, *::after {
+            box-sizing: inherit;
+          }
+          html {
             font-size: 62.5%;
           }
           html, body {
@@ -632,9 +665,6 @@ exports[`<AppContainer /> with className matches its snapshot 1`] = `
             padding-left: 0px;
             padding-right: 0px;
             padding-top: 0px;
-          }
-          *, *::before, *::after {
-            box-sizing: inherit;
           }
     >
       app container text
@@ -951,6 +981,34 @@ exports[`<AppContainer /> with default options matches its snapshot 1`] = `
   }
 >
   <Customizer
+    scopedSettings={
+      Object {
+        "CalloutContent": Object {
+          "styles": Object {
+            "calloutMain": Object {
+              "boxSizing": "border-box",
+              "selectors": Object {
+                "*, *::before, *::after": Object {
+                  "boxSizing": "inherit",
+                },
+              },
+            },
+          },
+        },
+        "Modal": Object {
+          "styles": Object {
+            "root": Object {
+              "boxSizing": "border-box",
+              "selectors": Object {
+                "*, *::before, *::after": Object {
+                  "boxSizing": "inherit",
+                },
+              },
+            },
+          },
+        },
+      }
+    }
     settings={
       Object {
         "theme": Object {
@@ -1261,8 +1319,13 @@ exports[`<AppContainer /> with default options matches its snapshot 1`] = `
     <div
       className=
           y-appContainer
-          html {
+          {
             box-sizing: border-box;
+          }
+          & *, *::before, *::after {
+            box-sizing: inherit;
+          }
+          html {
             font-size: 62.5%;
           }
           html, body {
@@ -1274,9 +1337,6 @@ exports[`<AppContainer /> with default options matches its snapshot 1`] = `
             padding-left: 0px;
             padding-right: 0px;
             padding-top: 0px;
-          }
-          *, *::before, *::after {
-            box-sizing: inherit;
           }
     >
       app container text
@@ -1593,6 +1653,34 @@ exports[`<AppContainer /> with theme matches its snapshot 1`] = `
   }
 >
   <Customizer
+    scopedSettings={
+      Object {
+        "CalloutContent": Object {
+          "styles": Object {
+            "calloutMain": Object {
+              "boxSizing": "border-box",
+              "selectors": Object {
+                "*, *::before, *::after": Object {
+                  "boxSizing": "inherit",
+                },
+              },
+            },
+          },
+        },
+        "Modal": Object {
+          "styles": Object {
+            "root": Object {
+              "boxSizing": "border-box",
+              "selectors": Object {
+                "*, *::before, *::after": Object {
+                  "boxSizing": "inherit",
+                },
+              },
+            },
+          },
+        },
+      }
+    }
     settings={
       Object {
         "theme": Object {
@@ -1903,8 +1991,13 @@ exports[`<AppContainer /> with theme matches its snapshot 1`] = `
     <div
       className=
           y-appContainer
-          html {
+          {
             box-sizing: border-box;
+          }
+          & *, *::before, *::after {
+            box-sizing: inherit;
+          }
+          html {
             font-size: 62.5%;
           }
           html, body {
@@ -1916,9 +2009,6 @@ exports[`<AppContainer /> with theme matches its snapshot 1`] = `
             padding-left: 0px;
             padding-right: 0px;
             padding-top: 0px;
-          }
-          *, *::before, *::after {
-            box-sizing: inherit;
           }
     >
       app container text


### PR DESCRIPTION
Global box-sizing broke a config panel in SP. This moves the rule to AppContainer, and adds override styles for CalloutContent and Modal components since they render in a separate layer.

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [x] Component is unit tested.
