### PR TITLE
Fix previewcard description to be consistent with the implementation.

### DIFF
--- a/src/components/PreviewCard/PreviewCard.types.ts
+++ b/src/components/PreviewCard/PreviewCard.types.ts
@@ -18,8 +18,7 @@ export interface PreviewCardProps extends BaseComponentProps {
   isDescriptionEditable?: boolean;
 
   /**
-   * Will display on the left of the PreviewCard. If not provided the image will be replaced
-   * by an icon depending on the file type.
+   * If provided, will display on the left of the PreviewCard.
    */
   imageUrl?: string;
 


### PR DESCRIPTION
PreviewCard does not use any fallback icon if imageUrl is not present.
Issue reported here: https://github.com/Microsoft/YamUI/issues/530

That functionality was originally intended but not anymore.

## Pull request checklist

* [x] Component `README.md` file is up-to-date.
* [x] Component is unit tested.
