### PR TITLE
refactor(YamUI): Modify indentation of ChoiceGroup component

### DIFF
--- a/src/components/ChoiceGroup/ChoiceGroup.styles.tsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.styles.tsx
@@ -26,8 +26,12 @@ export const getOptionStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGro
       minHeight: 0,
     },
     field: {
-      paddingLeft: '2.6rem',
+      paddingLeft: '0',
+      textIndent: '2.6rem',
       selectors: {
+        span: {
+          textIndent: '0',
+        },
         ':before': {
           borderColor: checked || focused ? theme.palette.themePrimary : theme.palette.neutralDark,
           borderWidth: checked ? '2px' : '1px',

--- a/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -28,13 +28,17 @@ exports[`<ChoiceGroup /> when \`props.selectedKey\` is set renders as expected 1
 exports[`<ChoiceGroup /> with minimal props option styled as expected 1`] = `
 Object {
   "field": Object {
-    "paddingLeft": "2.6rem",
+    "paddingLeft": "0",
     "selectors": Object {
       ":before": Object {
         "borderColor": "#dde0e6",
         "borderWidth": "1px",
       },
+      "span": Object {
+        "textIndent": "0",
+      },
     },
+    "textIndent": "2.6rem",
   },
   "root": Object {
     "marginBottom": "1.2rem",
@@ -144,13 +148,17 @@ exports[`<ChoiceGroup /> with minimal props when a change is triggered with an o
 exports[`<ChoiceGroup /> with minimal props when checked, option styled as expected 1`] = `
 Object {
   "field": Object {
-    "paddingLeft": "2.6rem",
+    "paddingLeft": "0",
     "selectors": Object {
       ":before": Object {
         "borderColor": "#6c98d9",
         "borderWidth": "2px",
       },
+      "span": Object {
+        "textIndent": "0",
+      },
     },
+    "textIndent": "2.6rem",
   },
   "root": Object {
     "marginBottom": "1.2rem",


### PR DESCRIPTION
Modify indentation of ChoiceGroup component to more closely match polls on Yammer.com (https://yammer.visualstudio.com/frontend/_workitems/edit/19062)

Currently on Modern Client:
![screen shot 2018-09-19 at 5 14 56 pm](https://user-images.githubusercontent.com/569537/45788487-a86cfd80-bc2f-11e8-8560-8bb3caf56960.png)

With this PR change:
![screen shot 2018-09-19 at 5 11 41 pm](https://user-images.githubusercontent.com/569537/45788501-b7ec4680-bc2f-11e8-8a1a-3c2fd3ac27a7.png)
